### PR TITLE
Adding .ejs and .hbs files types to be recognized as html

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -6,6 +6,8 @@
   'inc'
   'tmpl'
   'tpl'
+  'ejs'
+  'hbs'
 ]
 'firstLineMatch': '<(?i:(!DOCTYPE\\s*)?html)'
 'injections':


### PR DESCRIPTION
Tested locally and this change allows .ejs and .hbs to be auto-detected as html file types.
