### PR TITLE
Remove inc file extension as it is used for PHP, not HTML

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -1,11 +1,10 @@
 'fileTypes': [
-  'html'
   'htm'
+  'html'
   'shtml'
-  'xhtml'
-  'inc'
   'tmpl'
   'tpl'
+  'xhtml'
 ]
 'firstLineMatch': '<(?i:(!DOCTYPE\\s*)?html)'
 'injections':


### PR DESCRIPTION
- Removed `inc` file extension as it is for PHP, not HTML
- Alphabetically sort the extensions
