### PR TITLE
Fix issue with tag names containing a '-'

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -20,7 +20,7 @@
 'name': 'HTML'
 'patterns': [
   {
-    'begin': '(<)([a-zA-Z0-9:]++)(?=[^>]*></\\2>)'
+    'begin': '(<)([a-zA-Z0-9:-]++)(?=[^>]*></\\2>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'
@@ -287,7 +287,7 @@
     ]
   }
   {
-    'begin': '(</?)([a-zA-Z0-9:]+)'
+    'begin': '(</?)([a-zA-Z0-9:-]+)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'


### PR DESCRIPTION
This fixes the issue so that highlighting of elements with names containing a '-' go from this:

![screen shot 2014-05-09 at 7 04 34 pm](https://cloud.githubusercontent.com/assets/1730681/2934931/195918c0-d7e3-11e3-89f3-e56cbde2e431.png)

to this:

![screen shot 2014-05-09 at 7 18 26 pm](https://cloud.githubusercontent.com/assets/1730681/2934911/8104a342-d7e1-11e3-8b42-a310f4f428e1.png)
