### PR TITLE
Remove injection grammer rule

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -8,15 +8,6 @@
   'xhtml'
 ]
 'firstLineMatch': '<(?i:(!DOCTYPE\\s*)?html)'
-'injections':
-  'R:text.html - comment.block':
-    'comment': 'Use R: to ensure this matches after any other injections.'
-    'patterns': [
-      {
-        'match': '<'
-        'name': 'invalid.illegal.bad-angle-bracket.html'
-      }
-    ]
 'name': 'HTML'
 'patterns': [
   {


### PR DESCRIPTION
This pull request removes a grammar rule that's causing strange syntax highlighting for embedded JavaScript code.

The problem is whenever an angle bracket `<` appears inside a JS string literal, it's given the class `invalid.illegal.bad-angle-bracket.html`.

This grammar rule dates back to the TextMate days. It was added to detect invalid embedded PHP syntax like `<?php < ?>`.

https://github.com/textmate/html.tmbundle/commit/899238fa2c33a027e238408965d3fe29fd8f93ae
https://github.com/textmate/html.tmbundle/commit/2e855b7ec7853cd7db57d96dc1e74aaf40d7ea06
https://github.com/textmate/html.tmbundle/commit/87009dc24f2133df44ca4c273af4558a319e4cda

However, in its current form, this rule is being liberally injected into all embedded grammars, like the JavaScript grammar.

The solution taken by the HTML language authors for Sublime Text 2 was to remove the grammar rule. And I propose we do the same.

Here's a couple screenshots to illustrate the problem and the applied fix:
#### Problem

![screen_shot_2014-08-07_at_1_56_30_pm](https://cloud.githubusercontent.com/assets/5688/3849090/dae1a1be-1e75-11e4-8b4c-cd4a6de07053.png)
#### Fixed

![screen_shot_2014-08-07_at_1_57_55_pm](https://cloud.githubusercontent.com/assets/5688/3849096/e10de638-1e75-11e4-9272-93cccd502af6.png)

I'm not opposed to injecting rules into other grammars. Though, I'm sure you can see how a poorly implemented rule can cause unwanted syntax highlighting.
