### PR TITLE
Include Handlebars in file types

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -2,6 +2,8 @@
 'fileTypes': [
   'htm'
   'html'
+  'hbs'
+  'handlebars'
   'shtml'
   'tmpl'
   'tpl'


### PR DESCRIPTION
As `tpl`’s already included, I don’t see why Handlebars templates couldn’t also be.
I’m sure you’ll let me know if this is unwanted for some reason. :)
