### PR TITLE
Use .text.html, not .source.html as scope for handlebars templates

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -152,7 +152,7 @@
     'endCaptures':
       '2':
         'name': 'punctuation.definition.tag.html'
-    'name': 'source.embedded.html'
+    'name': 'text.embedded.html'
     'patterns': [
       {
         'include': '#tag-stuff'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -23,8 +23,8 @@ describe 'HTML grammar', ->
         </script>
       '''
 
-      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.embedded.html']
-      expect(lines[1][1]).toEqual value: '<', scopes: ['text.html.basic', 'source.embedded.html', 'meta.tag.block.any.html', 'punctuation.definition.tag.begin.html']
+      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'text.embedded.html']
+      expect(lines[1][1]).toEqual value: '<', scopes: ['text.html.basic', 'text.embedded.html', 'meta.tag.block.any.html', 'punctuation.definition.tag.begin.html']
 
   describe 'CoffeeScript script tags', ->
     it 'tokenizes the content inside the tag as CoffeeScript', ->


### PR DESCRIPTION
This way, the templates match the `text.html` scoped properties.

Fixes atom/atom#4704
