### PR TITLE
remove firstLineMatch; add svg

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -7,6 +7,7 @@
   'tmpl'
   'tpl'
   'xhtml'
+  'svg'
 ]
 'name': 'HTML'
 'patterns': [

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -8,7 +8,6 @@
   'tpl'
   'xhtml'
 ]
-'firstLineMatch': '<(?i:(!DOCTYPE\\s*)?html)'
 'name': 'HTML'
 'patterns': [
   {


### PR DESCRIPTION
When I open file with any extension(`.htmlx` for example) the first line of which is `<html>` that file auto detects as HTML, even if there is a grammar for that extension.

SVG was highlighted as XML and wrong highlighted unquoted attr value. Now it should look better.