### PR TITLE
Add type attribute to button snippet

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -42,7 +42,7 @@
     'body': '<br>'
   'Button':
     'prefix': 'button'
-    'body': '<button name="${1:button}">$2</button>$0'
+    'body': '<button type="${1:button}"${2: name="${3:button}"}>$4</button>$0'
   # C
   'Canvas':
     'prefix': 'canvas'


### PR DESCRIPTION
In my experience, the `type` attribute is used as frequently as (if not more than) the `name` attribute when creating a button. This PR adds the `type` attribute to the snippet and allows for removing the `name` attribute quickly.