### PR TITLE
Improve label snippet

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -181,7 +181,7 @@
   # L
   'Label':
     'prefix': 'label'
-    'body': '<label ${1:for="$2"}></label>$0'
+    'body': '<label${1: for="$2"}>$3</label>$0'
   'Legend':
     'prefix': 'legend'
     'body': '<legend>$1</legend>$0'


### PR DESCRIPTION
- Allow for easy removal of `for` attribute and prefix space
- Add `$3` tab index within generated `<label>`