### PR TITLE
Improve `script` snippet argument template

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -275,7 +275,7 @@
     'body': '<samp>$1</samp>$0'
   'Script':
     'prefix': 'script'
-    'body': '<script charset="utf-8">\n\t$1\n</script>'
+    'body': '<script${1: type="${2:text/javascript}"}>\n\t$3\n</script>'
   'Script With External Source':
     'prefix': 'scriptsrc'
     'body': '<script src="$1" charset="${2:utf-8}"></script>$0'


### PR DESCRIPTION
This replaces the `charset` attribute template with `type`. The `type` attribute template defaults to `text/javascript`, but can be changed by tabbing to the next arguments. In addition removing the entire `type` attribute is trivial.

Resolves #53 

![script-snippet](https://cloud.githubusercontent.com/assets/3622/7113175/6c47a80a-e1d1-11e4-8096-57a3238292d4.gif)

/cc @atom/owners 