### PR TITLE
Fixed so php tags works without space after html tags

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -336,16 +336,16 @@
     'name': 'invalid.illegal.incomplete.html'
   }
   {
-    'match': '><'
+    'match': '(?!\\?)><(?!\\?)'
     'name': 'meta.scope.outside-tag.html'
   }
   {
-    'match': '(?<=>)(<)'
+    'match': '(?<=>)(<(?!\\?))'
     'name': 'meta.scope.outside-tag.html'
   }
   {
     'begin': '(?<=>)'
-    'end': '(?=<)'
+    'end': '(?=<(?!\\?))'
     'name': 'meta.scope.outside-tag.html'
     'patterns': [
       {

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -28,6 +28,11 @@ describe 'HTML grammar', ->
       lines = grammar.tokenizeLines '<?'
       expect(lines[0][0]).toEqual value: '<?', scopes: ['text.html.basic']
 
+    it 'tokenizes ?><? without locking up', ->
+      lines = grammar.tokenizeLines '?><?'
+      expect(lines[0][0]).toEqual value: '?>', scopes: ['text.html.basic']
+      expect(lines[0][1]).toEqual value: '<?', scopes: ['text.html.basic', 'meta.scope.outside-tag.html']
+
     it 'tokenizes >< as html without locking up', ->
       lines = grammar.tokenizeLines '><'
       expect(lines[0][0]).toEqual value: '><', scopes: ['text.html.basic', 'meta.scope.outside-tag.html']


### PR DESCRIPTION
This pull request will fix https://github.com/atom/language-html/issues/60