### PR TITLE
Include meta charset declaration and DOCTYPE declaration in HTML boilerplate snippet.

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -156,7 +156,7 @@
     'body': '<hr>'
   'HTML':
     'prefix': 'html'
-    'body': '<html>\n\t<head>\n\t\t<title>$1</title>\n\t</head>\n\t<body>\n\t\t$2\n\t</body>\n</html>'
+    'body': '<!DOCTYPE html>\n<html>\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$1</title>\n\t</head>\n\t<body>\n\t\t$2\n\t</body>\n</html>'
   # I
   'Italic':
     'prefix': 'i'


### PR DESCRIPTION
Exactly what it says on the title. The DOCTYPE and charset declarations are required for valid HTML5.