### PR TITLE
Update language-html.cson for Japanese

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -157,6 +157,9 @@
   'HTML':
     'prefix': 'html'
     'body': '<!DOCTYPE html>\n<html>\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$1</title>\n\t</head>\n\t<body>\n\t\t$2\n\t</body>\n</html>'
+  'HTML Japanese':
+    'prefix': 'htmlja'
+    'body': '<!DOCTYPE html>\n<html lang="ja">\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$1</title>\n\t</head>\n\t<body>\n\t\t$2\n\t</body>\n</html>'
   # I
   'Italic':
     'prefix': 'i'


### PR DESCRIPTION
Modified to be able to output the structure of HTML suitable for Japanese when you entered the `htmlja`.