### PR TITLE
Fix embedded js scope

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -184,7 +184,7 @@
     'endCaptures':
       '2':
         'name': 'punctuation.definition.tag.html'
-    'name': 'source.coffee.embedded.html'
+    'contentName': 'source.coffee.embedded.html'
     'patterns': [
       {
         'include': '#tag-stuff'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -223,6 +223,7 @@
     'endCaptures':
       '2':
         'name': 'punctuation.definition.tag.html'
+    'contentName': 'source.js.embedded.html'
     'patterns': [
       {
         'include': '#tag-stuff'
@@ -235,7 +236,6 @@
           '2':
             'name': 'entity.name.tag.script.html'
         'end': '(</)((?i:script))'
-        'contentName': 'source.js.embedded.html'
         'patterns': [
           {
             'captures':

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -235,6 +235,7 @@
           '2':
             'name': 'entity.name.tag.script.html'
         'end': '(</)((?i:script))'
+        'contentName': 'source.js.embedded.html'
         'patterns': [
           {
             'captures':
@@ -252,12 +253,7 @@
             'name': 'comment.block.js'
           }
           {
-            'begin': '(?=.)'
-            'end': '(?=</script)'
-            'name': 'source.js.embedded.html'
-            'patterns': [{
-              'include': 'source.js'
-            }]
+            'include': 'source.js'
           }
         ]
       }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -253,7 +253,12 @@
             'name': 'comment.block.js'
           }
           {
-            'include': 'source.js'
+            'begin': '(?=.)'
+            'end': '(?=</script)'
+            'name': 'source.js.embedded.html'
+            'patterns': [{
+              'include': 'source.js'
+            }]
           }
         ]
       }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -223,7 +223,6 @@
     'endCaptures':
       '2':
         'name': 'punctuation.definition.tag.html'
-    'name': 'source.js.embedded.html'
     'patterns': [
       {
         'include': '#tag-stuff'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -152,7 +152,7 @@
     'endCaptures':
       '2':
         'name': 'punctuation.definition.tag.html'
-    'name': 'text.embedded.html'
+    'contentName': 'text.embedded.html'
     'patterns': [
       {
         'include': '#tag-stuff'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -61,6 +61,22 @@ describe 'HTML grammar', ->
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.coffee.embedded.html']
       expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'storage.type.function.coffee']
 
+  describe 'JavaScript script tags', ->
+    beforeEach ->
+      waitsForPromise -> atom.packages.activatePackage('language-javascript')
+
+    it 'tokenizes the content inside the tag as JavaScript', ->
+      lines = grammar.tokenizeLines '''
+        <script id='id' type='text/javascript'>
+          var hi = 'hi'
+        </script>
+      '''
+
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
+
+      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.js.embedded.html']
+      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.modifier.js']
+
   describe "comments", ->
     it "tokenizes -- as an error", ->
       {tokens} = grammar.tokenizeLine '<!-- some comment --->'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -58,6 +58,7 @@ describe 'HTML grammar', ->
         </script>
       '''
 
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.coffee.embedded.html']
       expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'storage.type.function.coffee']
 

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -47,6 +47,7 @@ describe 'HTML grammar', ->
         </script>
       '''
 
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'text.embedded.html']
       expect(lines[1][1]).toEqual value: '<', scopes: ['text.html.basic', 'text.embedded.html', 'meta.tag.block.any.html', 'punctuation.definition.tag.begin.html']
 


### PR DESCRIPTION
Fixes #4

The issue here is that the entire line, including script tags and whitespace is all tagged with the `source.js.embedded.html` scope. 

![screen shot 2015-07-24 at 5 00 00 pm](https://cloud.githubusercontent.com/assets/69169/8886814/8c7b9092-3225-11e5-9be9-716b1f710626.png)

My goal is to just tag the contents between the tags with `source.js.embedded.html`. 

@kevinsawicki not sure if you have a good technique for tagging just the content between the `start` and `end` captures.

cc @mnquintana 