### PR TITLE
Disable snippets in embedded contexts like <script> or <style>

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -369,8 +369,9 @@
     'body': '<wbr>'
 
 
-# These null out the snippets so the snippets are no available when in a tag
-'.text.html .meta.tag':
+# These null out the snippets so the snippets are not available when in a tag or
+# in embedded contexts like <script> and <style>
+'.text.html .meta.tag, .text.html .embedded':
   # A
   'Anchor':
     'prefix': 'a'


### PR DESCRIPTION
When inside a `<script>` or `<style>` element, HTML snippets still appear. This PR disables that behavior.

Before / After

![style](https://cloud.githubusercontent.com/assets/468153/9985497/b95668b4-5fe1-11e5-9dce-05523b28d72e.PNG)

![script](https://cloud.githubusercontent.com/assets/468153/9985499/bb9a7caa-5fe1-11e5-92c6-05a966d0c390.PNG)
