### PR TITLE
Fix improper tokenization of `script` tags

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+
+Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
+
+-->
+
+### Prerequisites
+
+* [ ] Put an X between the brackets on this line if you have done all of the following:
+    * Reproduced the problem in Safe Mode: http://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode
+    * Followed all applicable steps in the debugging guide: http://flight-manual.atom.io/hacking-atom/sections/debugging/
+    * Checked the FAQs on the message board for common solutions: https://discuss.atom.io/c/faq
+    * Checked that your issue isn't already filed: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aatom
+    * Checked that there is not already an Atom package that provides the described functionality: https://atom.io/packages
+
+### Description
+
+[Description of the issue]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+**Reproduces how often:** [What percentage of the time does it reproduce?]
+
+### Versions
+
+You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running.
+
+### Additional Information
+
+Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+### Requirements
+
+* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* All new code requires tests to ensure against regressions
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+## Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Benefits
+
+<!-- What benefits will be realized by the code change? -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Applicable Issues
+
+<!-- Enter any applicable Issues here -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ We must be able to understand the design of your change from this description. I
 
 -->
 
-## Alternate Designs
+### Alternate Designs
 
 <!-- Explain what other alternates were considered and why the proposed version was selected -->
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # HTML language support in Atom
-[![OS X Build Status](https://travis-ci.org/atom/language-html.svg?branch=master)](https://travis-ci.org/atom/language-html)
+[![macOS Build Status](https://travis-ci.org/atom/language-html.svg?branch=master)](https://travis-ci.org/atom/language-html)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/t6pk6mmdgcelfg85/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/language-html/branch/master)
 [![Dependency Status](https://david-dm.org/atom/language-html.svg)](https://david-dm.org/atom/language-html) 
 
 Adds syntax highlighting and snippets to HTML files in Atom.
 
-Originally [converted](http://atom.io/docs/latest/converting-a-text-mate-bundle)
+Originally [converted](http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate)
 from the [HTML TextMate bundle](https://github.com/textmate/html.tmbundle).
 
 Contributions are greatly appreciated. Please fork this repository and open a

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# HTML language support in Atom [![Build Status](https://travis-ci.org/atom/language-html.svg?branch=master)](https://travis-ci.org/atom/language-html)
+# HTML language support in Atom
+[![OS X Build Status](https://travis-ci.org/atom/language-html.svg?branch=master)](https://travis-ci.org/atom/language-html)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/t6pk6mmdgcelfg85/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/language-html/branch/master)
+[![Dependency Status](https://david-dm.org/atom/language-html.svg)](https://david-dm.org/atom/language-html) 
 
 Adds syntax highlighting and snippets to HTML files in Atom.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+install:
+  - choco install atom -y
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - "%LOCALAPPDATA%/atom/bin/apm clean"
+  - "%LOCALAPPDATA%/atom/bin/apm install"
+
+build_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - "%LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom.cmd"
+
+test: off
+
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,27 @@
 version: "{build}"
 
-os: Windows Server 2012 R2
+platform: x64
+
+branches:
+    only:
+      - master
+
+clone_depth: 10
+
+skip_tags: true
+
+environment:
+  APM_TEST_PACKAGES:
+
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
 
 install:
-  - choco install atom -y
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - "%LOCALAPPDATA%/atom/bin/apm clean"
-  - "%LOCALAPPDATA%/atom/bin/apm install"
+  - ps: Install-Product node 4
 
 build_script:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - "%LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom.cmd"
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
 
 test: off
-
 deploy: off

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -9,7 +9,20 @@
   'tpl'
   'xhtml'
 ]
-'firstLineMatch': '<(?i:(!DOCTYPE\\s*)?html)'
+'firstLineMatch': '''(?xi)
+  # Document type definition
+  <(?:!DOCTYPE\\s*)?html
+  |
+  # Emacs modeline
+  -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+    html
+  (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+  |
+  # Vim modeline
+  (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+    x?html
+  (?=\\s|:|$)
+'''
 'name': 'HTML'
 'patterns': [
   {

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -242,7 +242,21 @@
     'contentName': 'source.js.embedded.html'
     'patterns': [
       {
-        'include': 'source.js'
+        'include': '#tag-stuff'
+      }
+      {
+        'begin': '(?<!</(?:script|SCRIPT))(>)'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.tag.html'
+          '2':
+            'name': 'entity.name.tag.script.html'
+        'end': '(</)((?i:script))'
+        'patterns': [
+          {
+            'include': 'source.js'
+          }
+        ]
       }
     ]
   }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -449,7 +449,7 @@
       }
     ]
   'tag-generic-attribute':
-    'match': '(?<=[^=]|^)\\b([a-zA-Z0-9:-]+)'
+    'match': '(?<!=)\\b([a-zA-Z0-9:-]+)'
     'name': 'entity.other.attribute-name.html'
   'tag-id-attribute':
     'begin': '\\b(id)\\b\\s*(=)'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -144,7 +144,7 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)script)\\b(.*?\\btype\\s*=\\s*[\'"]?text/(x-handlebars|(x-handlebars-|ng-)?template|html)[\'"]?.*?)(>)'
+    'begin': '(?:^\\s+)?(<)((?i)script)\\b(.*?\\btype\\s*=\\s*[\'"]?text/(x-handlebars|(x-handlebars-|ng-|x-template)?template|html)[\'"]?.*?)(>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -242,36 +242,7 @@
     'contentName': 'source.js.embedded.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
-      }
-      {
-        'begin': '(?<!</(?:script|SCRIPT))(>)'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.tag.html'
-          '2':
-            'name': 'entity.name.tag.script.html'
-        'end': '(</)((?i:script))'
-        'patterns': [
-          {
-            'captures':
-              '1':
-                'name': 'punctuation.definition.comment.js'
-            'match': '(//).*?((?=</script)|$\\n?)'
-            'name': 'comment.line.double-slash.js'
-          }
-          {
-            'begin': '/\\*'
-            'captures':
-              '0':
-                'name': 'punctuation.definition.comment.js'
-            'end': '\\*/|(?=</script)'
-            'name': 'comment.block.js'
-          }
-          {
-            'include': 'source.js'
-          }
-        ]
+        'include': 'source.js'
       }
     ]
   }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -124,7 +124,7 @@
     'include': '#embedded-code'
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)style)\\b(.*?)(>)'
+    'begin': '(?:^\\s+)?(<)((?i)style)\\b(.*?)(/?>)' # Match an optional /> here because <style/> is allowed
     'captures':
       '1':
         'name': 'punctuation.definition.tag.html'
@@ -138,7 +138,7 @@
         ]
       '4':
         'name': 'punctuation.definition.tag.html'
-    'end': '(</)((?i)style)(>)'
+    'end': '(?<=/>)|(</)((?i)style)(>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -350,7 +350,7 @@
   'entities':
     'patterns': [
       {
-        'begin': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)'
+        'begin': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(?=;)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.entity.begin.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -449,7 +449,7 @@
       }
     ]
   'tag-generic-attribute':
-    'match': '(?<=[^=])\\b([a-zA-Z0-9:-]+)'
+    'match': '(?<=[^=]|^)\\b([a-zA-Z0-9:-]+)'
     'name': 'entity.other.attribute-name.html'
   'tag-id-attribute':
     'begin': '\\b(id)\\b\\s*(=)'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -323,12 +323,16 @@
   'entities':
     'patterns': [
       {
-        'captures':
+        'begin': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)'
+        'beginCaptures':
           '1':
-            'name': 'punctuation.definition.entity.html'
-          '3':
-            'name': 'punctuation.definition.entity.html'
-        'match': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)'
+            'name': 'punctuation.definition.entity.begin.html'
+          '2':
+            'name': 'entity.name.entity.other.html'
+        'end': '(;)'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.entity.end.html'
         'name': 'constant.character.entity.html'
       }
       {

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -254,6 +254,21 @@
         'end': '(</)((?i:script))'
         'patterns': [
           {
+            'captures':
+              '1':
+                'name': 'punctuation.definition.comment.js'
+            'match': '(//).*?((?=</script)|$\\n?)'
+            'name': 'comment.line.double-slash.js'
+          }
+          {
+            'begin': '/\\*'
+            'captures':
+              '0':
+                'name': 'punctuation.definition.comment.js'
+            'end': '\\*/|(?=</script)'
+            'name': 'comment.block.js'
+          }
+          {
             'include': 'source.js'
           }
         ]

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -350,15 +350,13 @@
   'entities':
     'patterns': [
       {
-        'begin': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(?=;)'
-        'beginCaptures':
+        'match': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)'
+        'captures':
           '1':
             'name': 'punctuation.definition.entity.begin.html'
           '2':
             'name': 'entity.name.entity.other.html'
-        'end': ';'
-        'endCaptures':
-          '0':
+          '3':
             'name': 'punctuation.definition.entity.end.html'
         'name': 'constant.character.entity.html'
       }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -329,9 +329,9 @@
             'name': 'punctuation.definition.entity.begin.html'
           '2':
             'name': 'entity.name.entity.other.html'
-        'end': '(;)'
+        'end': ';'
         'endCaptures':
-          '1':
+          '0':
             'name': 'punctuation.definition.entity.end.html'
         'name': 'constant.character.entity.html'
       }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -144,7 +144,7 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)script)\\b(.*?\\btype\\s*=\\s*[\'"]?text/(x-handlebars|(x-handlebars-|ng-|x-template)?template|html)[\'"]?.*?)(>)'
+    'begin': '(?:^\\s+)?(<)((?i)script)\\b(.*?\\btype\\s*=\\s*[\'"]?text/(x-handlebars|(x-(handlebars-)?|ng-)?template|html)[\'"]?.*?)(>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "devDependencies": {
-    "atom-grammar-test": "^0.1.1",
+    "atom-grammar-test": "^0.1.2",
     "coffeelint": "^1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "devDependencies": {
-    "atom-grammar-test": "^0.1.2",
+    "atom-grammar-test": "^0.3.0",
     "coffeelint": "^1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "devDependencies": {
+    "atom-grammar-test": "^0.1.1",
     "coffeelint": "^1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.47.4",
+  "version": "0.47.5",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.47.3",
+  "version": "0.47.4",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.45.1",
+  "version": "0.46.0",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "dependencies": {
-    "atom-grammar-test": "0.6.0"
+    "atom-grammar-test": "^0.6.3"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   "bugs": {
     "url": "https://github.com/atom/language-html/issues"
   },
+  "dependencies": {
+    "atom-grammar-test": "0.6.0"
+  },
   "devDependencies": {
-    "atom-grammar-test": "^0.3.0",
     "coffeelint": "^1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-html",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",

--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -7,7 +7,7 @@
       <(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\\b|[^>]*/>)
       ([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*</\\1>)
       |<!--(?!.*-->)
-      |<\\?php.+?\\b(if|else(?:if)?|for(?:each)?|while)\\b.*:(?!.*end\\1)
+      |<\\?php.+?\\b(if|else(?:if)?|for(?:each)?|while)\\b.*:(?!.*end\\2)
       |\\{[^}"\']*$
     '''
     'decreaseIndentPattern': '''(?x)

--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -3,18 +3,19 @@
     'commentStart': '<!-- '
     'commentEnd': ' -->'
     'foldEndPattern': '(?x)\n\t\t(</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl|section|article|header|footer|nav|aside)>\n\t\t|^(?!.*?<!--).*?--\\s*>\n\t\t|^<!--\\ end\\ tminclude\\ -->$\n\t\t|<\\?(?:php)?.*\\bend(if|for(each)?|while)\\b\n\t\t|\\{\\{?/(if|foreach|capture|literal|foreach|php|section|strip)\n\t\t|^[^{]*\\}\n\t\t|^\\s*\\)[,;]\n\t\t)'
-    'increaseIndentPattern': '(?x)
+    'increaseIndentPattern': '''(?x)
       <(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\\b|[^>]*/>)
       ([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*</\\1>)
       |<!--(?!.*-->)
       |<\\?php.+?\\b(if|else(?:if)?|for(?:each)?|while)\\b.*:(?!.*end\\1)
       |\\{[^}"\']*$
-    '
-    'decreaseIndentPattern': '(?x)
+    '''
+    'decreaseIndentPattern': '''(?x)
       ^\\s*
       (</(?!html)
         [-_\\.A-Za-z0-9]+\\b[^>]*>
         |-->
         |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while))
         |\\}
-      )'
+      )
+    '''

--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -15,7 +15,7 @@
       (</(?!html)
         [-_\\.A-Za-z0-9]+\\b[^>]*>
         |-->
-        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while)\\})
+        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while)|\\})
         |\\}
       )
     '''

--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -15,7 +15,7 @@
       (</(?!html)
         [-_\\.A-Za-z0-9]+\\b[^>]*>
         |-->
-        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while))
+        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while)\\})
         |\\}
       )
     '''

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -86,7 +86,7 @@
     'body': '<del>$1</del>$0'
   'Details':
     'prefix': 'details'
-    'body': '<details${1: open}>$2</details>$0'
+    'body': '<details${1: open}>\n\t$2\n</details>'
   'Definition':
     'prefix': 'dfn'
     'body': '<dfn>$1</dfn>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -215,7 +215,7 @@
     'body': '<menuitem type="${1:command}" label="${2:Save}">$0'
   'Meter':
     'prefix': 'meter'
-    'body': '<meter min="${1:200}" max="${2:500}" value="${3:350}">$0'
+    'body': '<meter value="$1"${2: min="${3:0}" max="${4:100}"}>$5</meter>$0'
   'Mail Anchor':
     'prefix': 'mailto'
     'body': '<a href="mailto:${1:joe@example.com}?subject=${2:feedback}">${3:email me}</a>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -77,7 +77,7 @@
     'body': '<data value="$1">$2</data>$0'
   'Data List':
     'prefix': 'datalist'
-    'body': '<datalist class="$1">\n\t$2\n</datalist>'
+    'body': '<datalist${1: class="$2"}>\n\t$3\n</datalist>'
   'Description':
     'prefix': 'dd'
     'body': '<dd>$1</dd>$0'
@@ -92,13 +92,13 @@
     'body': '<dfn>$1</dfn>$0'
   'Description List':
     'prefix': 'dl'
-    'body': '<dl class="$1">\n\t$2\n</dl>'
+    'body': '<dl${1: class="$2"}>\n\t$3\n</dl>'
   'Definition Term':
     'prefix': 'dt'
     'body': '<dt>$1</dt>$0'
   'Div':
     'prefix': 'div'
-    'body': '<div class="$2">\n\t$3\n</div>'
+    'body': '<div class="$1">\n\t$2\n</div>'
   # E
   'Emphasis':
     'prefix': 'em'
@@ -166,7 +166,7 @@
     'body': '<iframe src="$1" width="$2" height="$3">$4</iframe>$0'
   'Input':
     'prefix': 'input'
-    'body': '<input type="${1:button}" name="${2:name}" value="$3">$0'
+    'body': '<input type="${1:text}" name="$2" value="$3">$0'
   'Image':
     'prefix': 'img'
     'body': '<img src="$1" alt="$2">$0'
@@ -196,7 +196,7 @@
     'body': '<li>$1</li>$0'
   'Link':
     'prefix': 'link'
-    'body': '<link rel="${1:stylesheet}" href="${2:/css/master.css}" media="${3:screen}" title="${4:no title}">$0'
+    'body': '<link rel="${1:stylesheet}" href="${2:/css/master.css}">$0'
   # M
   'Main':
     'prefix': 'main'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -238,17 +238,17 @@
     'body': '<ol>\n\t$1\n</ol>'
   'Option Group':
     'prefix': 'optgroup'
-    'body': '<optgroup label="${1:Group 1}">\n\t$2\n</optgroup>'
+    'body': '<optgroup label="$1">\n\t$2\n</optgroup>'
   'Option':
-    'prefix': 'opt'
-    'body': '<option${1: value="${2:option}"}>${3:option}</option>$0'
+    'prefix': 'option'
+    'body': '<option${1: value="$2"}>$3</option>$0'
   'Output':
     'prefix': 'output'
     'body': '<output name="${1:result}">$2</output>$0'
   # P
   'Paragraph':
     'prefix': 'p'
-    'body': '<p>\n\t$1\n</p>'
+    'body': '<p>$1</p>$0'
   'Parameter':
     'prefix': 'param'
     'body': '<param name="${1:foo}" value="${2:bar}">$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -330,7 +330,7 @@
     'body': '<tbody>\n\t$1\n</tbody>'
   'Table Cell':
     'prefix': 'td'
-    'body': '<td>\n\t$1\n</td>'
+    'body': '<td>$1</td>$0'
   'Template':
     'prefix': 'template'
     'body': '<template id="$1">\n\t$2\n</template>'
@@ -342,7 +342,7 @@
     'body': '<tfoot>\n\t$1\n</tfoot>'
   'Table Header Cell':
     'prefix': 'th'
-    'body': '<th>\n\t$1\n</th>'
+    'body': '<th>$1</th>$0'
   'Table Head':
     'prefix': 'thead'
     'body': '<thead>\n\t$1\n</thead>'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -33,10 +33,10 @@
     'body': '<base href="${1:#}" target="${2:_blank}">$0'
   'Bi-Directional Isolation':
     'prefix': 'bdi'
-    'body': '<bdi dir="${1:auto}">$2</bdi>$0'
+    'body': '<bdi${1: dir="${2:rtl}"}>$3</bdi>$0'
   'Bi-Directional Override':
     'prefix': 'bdo'
-    'body': '<bdo dir="${1:auto}">$2</bdo>$0'
+    'body': '<bdo dir="${1:rtl}">$2</bdo>$0'
   'Blockquote':
     'prefix': 'blockquote'
     'body': '<blockquote cite="${1:http://}">\n\t$2\n</blockquote>'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -251,10 +251,10 @@
     'body': '<p>$1</p>$0'
   'Parameter':
     'prefix': 'param'
-    'body': '<param name="${1:foo}" value="${2:bar}">$0'
+    'body': '<param name="$1" value="$2">$0'
   'Preformatted Text':
     'prefix': 'pre'
-    'body': '<pre>\n\t$1\n</pre>'
+    'body': '<pre>$1</pre>$0'
   'Progress':
     'prefix': 'progress'
     'body': '<progress value="${1:50}" max="${2:100}">${3:50%}</progress>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -257,11 +257,11 @@
     'body': '<pre>$1</pre>$0'
   'Progress':
     'prefix': 'progress'
-    'body': '<progress value="${1:50}" max="${2:100}">${3:50%}</progress>$0'
+    'body': '<progress value="${1:0}" max="${2:100}">${3:0%}</progress>$0'
   # Q
   'Quote':
     'prefix': 'q'
-    'body': '<q cite="$1">$2</q>$0'
+    'body': '<q${1: cite="$2"}>$3</q>$0'
   # R
   'Ruby Base':
     'prefix': 'rb'
@@ -302,7 +302,7 @@
     'body': '<small>$1</small>$0'
   'Source':
     'prefix': 'source'
-    'body': '<source src="${1:http://}" type="${2:mimetype}">$0'
+    'body': '<source src="${1:https://}" type="${2:video/}">$0'
   'Span':
     'prefix': 'span'
     'body': '<span>$1</span>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -164,12 +164,12 @@
   'Inline Frame':
     'prefix': 'iframe'
     'body': '<iframe src="$1" width="$2" height="$3">$4</iframe>$0'
-  'Input':
-    'prefix': 'input'
-    'body': '<input type="${1:text}" name="$2" value="$3">$0'
   'Image':
     'prefix': 'img'
     'body': '<img src="$1" alt="$2">$0'
+  'Input':
+    'prefix': 'input'
+    'body': '<input type="${1:text}" name="$2" value="$3">$0'
   'Import':
     'prefix': 'import'
     'body': '<link rel="import" href="$1">$0'
@@ -224,7 +224,7 @@
     'body': '<a href="mailto:${1:joe@example.com}?subject=${2:feedback}">${3:email me}</a>$0'
   'Meta':
     'prefix': 'meta'
-    'body': '<meta name="${1:name}" content="${2:content}">$0'
+    'body': '<meta name="${1:twitter:}" content="$2">$0'
   # N
   'Navigation':
     'prefix': 'nav'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -118,7 +118,7 @@
     'body': '<figcaption>$1</figcaption>$0'
   'Figure':
     'prefix': 'figure'
-    'body': '<figure>$1</figure>$0'
+    'body': '<figure>\n\t$1\n</figure>'
   'Footer':
     'prefix': 'footer'
     'body': '<footer>$1</footer>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -232,7 +232,7 @@
   # O
   'Object':
     'prefix': 'object'
-    'body': '<object data="${1:http://}" type="${2:mimetype}">$3</object>$0'
+    'body': '<object${1: type="$2"}${3: data="${4:https://}"}>\n\t$5\n</object>'
   'Ordered List':
     'prefix': 'ol'
     'body': '<ol>\n\t$1\n</ol>'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -336,7 +336,7 @@
     'body': '<template id="$1">\n\t$2\n</template>'
   'Text Area':
     'prefix': 'textarea'
-    'body': '<textarea name="${1:name}" rows="${2:8}" cols="${3:40}">$4</textarea>$0'
+    'body': '<textarea name="${1:name}" rows="${2:8}" cols="${3:80}">$4</textarea>$0'
   'Table Foot':
     'prefix': 'tfoot'
     'body': '<tfoot>\n\t$1\n</tfoot>'
@@ -351,7 +351,7 @@
     'body': '<time>$1</time>$0'
   'Title':
     'prefix': 'title'
-    'body': '<title>${1:Page Title}</title>$0'
+    'body': '<title>${1:Home}</title>$0'
   'Table Row':
     'prefix': 'tr'
     'body': '<tr>\n\t$1\n</tr>'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -112,7 +112,7 @@
     'body': '<link rel="shortcut icon" href="$1.ico">$0'
   'Fieldset':
     'prefix': 'fieldset'
-    'body': '<fieldset>$1</fieldset>$0'
+    'body': '<fieldset>\n\t$1\n</fieldset>'
   'Figure Caption':
     'prefix': 'figcaption'
     'body': '<figcaption>$1</figcaption>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -11,7 +11,7 @@
     'body': '<address ${1:class="$2"}>\n\t$3\n</address>'
   'Area':
     'prefix': 'area'
-    'body': '<area ${1:shape="${2:default}"} coords="$3" ${4:href="${5:#}"} />$0'
+    'body': '<area ${1:shape="${2:default}"} coords="$3" ${4:href="${5:#}"}>$0'
   'Article':
     'prefix': 'article'
     'body': '<article class="$1">\n\t$2\n</article>'
@@ -30,7 +30,7 @@
     'body': '<b>$1</b>$0'
   'Base':
     'prefix': 'base'
-    'body': '<base href="${1:#}" target="${2:_blank}" />$0'
+    'body': '<base href="${1:#}" target="${2:_blank}">$0'
   'Bi-Directional Isolation':
     'prefix': 'bdi'
     'body': '<bdi dir="${1:auto}">$2</bdi>$0'
@@ -172,7 +172,7 @@
     'body': '<input type="${1:button}" name="${2:name}" value="$3">$0'
   'Image':
     'prefix': 'img'
-    'body': '<img src="$1" alt="$2" />$0'
+    'body': '<img src="$1" alt="$2">$0'
   'Import':
     'prefix': 'import'
     'body': '<link rel="import" href="$1">$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -61,7 +61,7 @@
     'body': '<code>$1</code>$0'
   'Column':
     'prefix': 'col'
-    'body': '<col>$1</col>$0'
+    'body': '<col${1: span="${2:2}"}>$0'
   'Column Group':
     'prefix': 'colgroup'
     'body': '<colgroup>$1</colgroup>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -207,6 +207,9 @@
   'Mark':
     'prefix': 'mark'
     'body': '<mark>$1</mark>$0'
+  'MathML':
+    'prefix': 'math'
+    'body': '<math>\n\t$1\n</math>'
   'Menu':
     'prefix': 'menu'
     'body': '<menu>\n\t$1\n</menu>'
@@ -321,6 +324,9 @@
   'Superscript':
     'prefix': 'sup'
     'body': '<sup>$1</sup>$0'
+  'SVG':
+    'prefix': 'svg'
+    'body': '<svg>\n\t$1\n</svg>'
   # T
   'Table':
     'prefix': 'table'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -151,6 +151,9 @@
   'Header':
     'prefix': 'header'
     'body': '<header>\n\t$1\n</header>'
+  'Heading Group':
+    'prefix': 'hgroup'
+    'body': '<hgroup>\n\t$1\n</hgroup>'
   'Horizontal Rule':
     'prefix': 'hr'
     'body': '<hr>'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -8,10 +8,10 @@
     'body': '<abbr title="$1">$2</abbr>$0'
   'Address':
     'prefix': 'address'
-    'body': '<address ${1:class="$2"}>\n\t$3\n</address>'
+    'body': '<address${1: class="$2"}>\n\t$3\n</address>'
   'Area':
     'prefix': 'area'
-    'body': '<area ${1:shape="${2:default}"} coords="$3" ${4:href="${5:#}"}>$0'
+    'body': '<area${1: shape="${2:default}"} coords="$3"${4: href="${5:#}" alt="$6"}>$0'
   'Article':
     'prefix': 'article'
     'body': '<article class="$1">\n\t$2\n</article>'
@@ -89,7 +89,7 @@
     'body': '<del>$1</del>$0'
   'Details':
     'prefix': 'details'
-    'body': '<details ${1:open}>$2</details>$0'
+    'body': '<details${1: open}>$2</details>$0'
   'Definition':
     'prefix': 'dfn'
     'body': '<dfn>$1</dfn>$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -65,9 +65,6 @@
   'Column Group':
     'prefix': 'colgroup'
     'body': '<colgroup>$1</colgroup>$0'
-  'Content':
-    'prefix': 'content'
-    'body': '<content select="$1">$2</content>$0'
   'Comment':
     'prefix': '--'
     'body': '<!-- $1 -->$0'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -199,7 +199,7 @@
     'body': '<li>$1</li>$0'
   'Link':
     'prefix': 'link'
-    'body': '<link rel="${1:stylesheet}" href="${2:/css/master.css}" media="${3:screen}" title="${4:no title}" charset="${5:utf-8}">$0'
+    'body': '<link rel="${1:stylesheet}" href="${2:/css/master.css}" media="${3:screen}" title="${4:no title}">$0'
   # M
   'Main':
     'prefix': 'main'

--- a/spec/fixtures/syntax_test_html.html
+++ b/spec/fixtures/syntax_test_html.html
@@ -1,0 +1,29 @@
+<!-- SYNTAX TEST "text.html.basic" -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test HTML</title>
+        <script><!--
+        <!-- ^ entity.name.tag.script.html -->
+            var foo = 100;
+            var baz = function() {
+            <!-- <- source.js.embedded -->
+            }
+        //--></script>
+        <!-- ^ source.js.embedded.html -->
+        <!--     ^ entity.name.tag.script.html -->
+        <style type="text/css">
+        <!--    ^ entity.other.attribute-name -->
+            h2 {
+            <!-- <- source.css.embedded -->
+                font-family: "Arial";
+            }
+        </style>
+        <!-- ^ entity.name.tag.style.html -->
+        <style />
+    </head>
+    <body>
+        <!-- Comment -->
+        <!-- ^ comment.block.html -->
+    </body>
+</html>

--- a/spec/fixtures/syntax_test_html.html
+++ b/spec/fixtures/syntax_test_html.html
@@ -10,7 +10,7 @@
             <!-- <- source.js.embedded -->
             }
         //--></script>
-        <!-- ^ source.js.embedded.html -->
+        <!-- ^^ punctuation.definition.tag.html -->
         <!--     ^ entity.name.tag.script.html -->
         <style type="text/css">
         <!--    ^ entity.other.attribute-name -->
@@ -19,6 +19,7 @@
                 font-family: "Arial";
             }
         </style>
+    <!--^^ punctuation.definition.tag.html -->    
         <!-- ^ entity.name.tag.style.html -->
         <style />
     </head>

--- a/spec/fixtures/syntax_test_html_template_fragments.html
+++ b/spec/fixtures/syntax_test_html_template_fragments.html
@@ -1,0 +1,40 @@
+<!-- SYNTAX TEST "text.html.basic" -->
+<!DOCTYPE html>
+<html>
+    <body>
+        <!-- Ensure script tags used as html fragments are parsed as embedded html -->
+
+        <script type="text/html" id="myTemplate">
+        <!-- <- punctuation.definition.tag.html -->
+        <!-- ^ entity.name.tag.script.html -->
+            <ul>
+            <!-- <- text.embedded.html -->
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        </script>
+        <!-- <- punctuation.definition.tag.html -->
+
+        <script type="text/ng-template" id="myNgTemplate">
+        <!-- <- punctuation.definition.tag.html -->
+        <!-- ^ entity.name.tag.script.html -->
+            <ul>
+            <!-- <- text.embedded.html -->
+                <li ng-repeat="item in [1, 2, 3]">Item #{$index}</li>
+            </ul>
+        </script>
+        <!-- <- punctuation.definition.tag.html -->
+
+        <script type="text/x-handlebars" id="myHandlebarsTemplate">
+        <!-- <- punctuation.definition.tag.html -->
+        <!-- ^ entity.name.tag.script.html -->
+            <ul>
+            <!-- <- text.embedded.html -->
+            {{#each items}}
+                <li>Item {{@index}}</li>
+            </ul>
+        </script>
+        <!-- <- punctuation.definition.tag.html -->
+    </body>
+</html>

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -106,6 +106,21 @@ describe 'HTML grammar', ->
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.js.embedded.html']
       expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
 
+    it 'detects </script> tags even if they would otherwise be valid JavaScript', ->
+      # This spec relies on language-javascript's "embedded javascript.cson", so if it fails, look there
+      lines = grammar.tokenizeLines '''
+        <script>
+          var test = 'test</script>';
+          var shouldntbematched;
+      '''
+
+      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
+      expect(lines[1][5]).toEqual value: "'", scopes: ['text.html.basic', 'source.js.embedded.html', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
+      expect(lines[1][6]).toEqual value: 'test', scopes: ['text.html.basic', 'source.js.embedded.html', 'string.quoted.single.js']
+      expect(lines[1][7]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
+      expect(lines[1][10]).toEqual value: "';", scopes: ['text.html.basic']
+      expect(lines[2][0]).toEqual value: '  var shouldntbematched;', scopes: ['text.html.basic']
+
   describe "comments", ->
     it "tokenizes -- as an error", ->
       {tokens} = grammar.tokenizeLine '<!-- some comment --->'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -1,3 +1,6 @@
+path = require 'path'
+grammarTest = require 'atom-grammar-test'
+
 describe 'HTML grammar', ->
   grammar = null
 
@@ -118,3 +121,6 @@ describe 'HTML grammar', ->
       expect(tokens[2]).toEqual value: '--', scopes: ['text.html.basic', 'comment.block.html', 'invalid.illegal.bad-comments-or-CDATA.html']
       expect(tokens[3]).toEqual value: ' ', scopes: ['text.html.basic', 'comment.block.html']
       expect(tokens[4]).toEqual value: '-->', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.html']
+
+  grammarTest path.join(__dirname, 'fixtures/syntax_test_html.html')
+  grammarTest path.join(__dirname, 'fixtures/syntax_test_html_template_fragments.html')

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -88,8 +88,8 @@ describe 'HTML grammar', ->
 
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.coffee.embedded.html']
-      # TODO: Remove when Atom 1.22 reaches stable
-      if parseFloat(atom.getVersion()) <= 1.21
+      # TODO: Remove when Atom 1.21 reaches stable
+      if parseFloat(atom.getVersion()) <= 1.20
         expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'storage.type.function.coffee']
       else
         expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -133,3 +133,91 @@ describe 'HTML grammar', ->
       expect(tokens[3]).toEqual value: 'amp', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
       expect(tokens[4]).toEqual value: ';', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.end.html']
       expect(tokens[7]).toEqual value: 'a', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
+
+  describe "firstLineMatch", ->
+    it "recognises HTML5 doctypes", ->
+      expect(grammar.firstLineRegex.scanner.findNextMatchSync("<!DOCTYPE html>")).not.toBeNull()
+      expect(grammar.firstLineRegex.scanner.findNextMatchSync("<!doctype HTML>")).not.toBeNull()
+
+    it "recognises Emacs modelines", ->
+      valid = """
+        #-*- HTML -*-
+        #-*- mode: HTML -*-
+        /* -*-html-*- */
+        // -*- HTML -*-
+        /* -*- mode:HTML -*- */
+        // -*- font:bar;mode:HTML -*-
+        // -*- font:bar;mode:HTML;foo:bar; -*-
+        // -*-font:mode;mode:HTML-*-
+        // -*- foo:bar mode: html bar:baz -*-
+        " -*-foo:bar;mode:html;bar:foo-*- ";
+        " -*-font-mode:foo;mode:html;foo-bar:quux-*-"
+        "-*-font:x;foo:bar; mode : HTML; bar:foo;foooooo:baaaaar;fo:ba;-*-";
+        "-*- font:x;foo : bar ; mode : HtML ; bar : foo ; foooooo:baaaaar;fo:ba-*-";
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        /* --*html-*- */
+        /* -*-- HTML -*-
+        /* -*- -- HTML -*-
+        /* -*- HTM -;- -*-
+        // -*- xHTML -*-
+        // -*- HTML; -*-
+        // -*- html-stuff -*-
+        /* -*- model:html -*-
+        /* -*- indent-mode:html -*-
+        // -*- font:mode;html -*-
+        // -*- HTimL -*-
+        // -*- mode: -*- HTML
+        // -*- mode: -html -*-
+        // -*-font:mode;mode:html--*-
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it "recognises Vim modelines", ->
+      valid = """
+        vim: se filetype=html:
+        # vim: se ft=html:
+        # vim: set ft=HTML:
+        # vim: set filetype=XHTML:
+        # vim: ft=XHTML
+        # vim: syntax=HTML
+        # vim: se syntax=xhtml:
+        # ex: syntax=HTML
+        # vim:ft=html
+        # vim600: ft=xhtml
+        # vim>600: set ft=html:
+        # vi:noai:sw=3 ts=6 ft=html
+        # vi::::::::::noai:::::::::::: ft=html
+        # vim:ts=4:sts=4:sw=4:noexpandtab:ft=html
+        # vi:: noai : : : : sw   =3 ts   =6 ft  =html
+        # vim: ts=4: pi sts=4: ft=html: noexpandtab: sw=4:
+        # vim: ts=4 sts=4: ft=html noexpandtab:
+        # vim:noexpandtab sts=4 ft=html ts=4
+        # vim:noexpandtab:ft=html
+        # vim:ts=4:sts=4 ft=html:noexpandtab:\x20
+        # vim:noexpandtab titlestring=hi\|there\\\\ ft=html ts=4
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        ex: se filetype=html:
+        _vi: se filetype=HTML:
+         vi: se filetype=HTML
+        # vim set ft=html5
+        # vim: soft=html
+        # vim: clean-syntax=html:
+        # vim set ft=html:
+        # vim: setft=HTML:
+        # vim: se ft=html backupdir=tmp
+        # vim: set ft=HTML set cmdheight=1
+        # vim:noexpandtab sts:4 ft:HTML ts:4
+        # vim:noexpandtab titlestring=hi\\|there\\ ft=HTML ts=4
+        # vim:noexpandtab titlestring=hi\\|there\\\\\\ ft=HTML ts=4
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -124,3 +124,12 @@ describe 'HTML grammar', ->
 
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html.html')
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html_template_fragments.html')
+
+  describe "entities", ->
+    it "tokenizes & and characters after it", ->
+      {tokens} = grammar.tokenizeLine '& &amp; &a'
+
+      expect(tokens[0]).toEqual value: '&', scopes: ['text.html.basic', 'invalid.illegal.bad-ampersand.html']
+      expect(tokens[3]).toEqual value: 'amp', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
+      expect(tokens[4]).toEqual value: ';', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.end.html']
+      expect(tokens[7]).toEqual value: 'a', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -147,7 +147,7 @@ describe 'HTML grammar', ->
       expect(tokens[0]).toEqual value: '&', scopes: ['text.html.basic', 'invalid.illegal.bad-ampersand.html']
       expect(tokens[3]).toEqual value: 'amp', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
       expect(tokens[4]).toEqual value: ';', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.end.html']
-      expect(tokens[7]).toEqual value: 'a', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
+      expect(tokens[7]).toEqual value: 'a', scopes: ['text.html.basic']
 
   describe "firstLineMatch", ->
     it "recognises HTML5 doctypes", ->

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -126,9 +126,9 @@ describe 'HTML grammar', ->
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html_template_fragments.html')
 
   describe "attributes", ->
-     it "recognizes attributes", ->
-        lines = grammar.tokenizeLines '<span\nclass="foo">'
-        expect(lines[1][0]).toEqual value: 'class', scopes: ["text.html.basic", "meta.tag.inline.any.html", "entity.other.attribute-name.html"]
+    it "recognizes attributes", ->
+      lines = grammar.tokenizeLines '<span\nclass="foo">'
+      expect(lines[1][0]).toEqual value: 'class', scopes: ["text.html.basic", "meta.tag.inline.any.html", "entity.other.attribute-name.html"]
 
   describe "entities", ->
     it "tokenizes & and characters after it", ->

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -125,6 +125,11 @@ describe 'HTML grammar', ->
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html.html')
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html_template_fragments.html')
 
+  describe "attributes", ->
+     it "recognizes attributes", ->
+        lines = grammar.tokenizeLines '<span\nclass="foo">'
+        expect(lines[1][0]).toEqual value: 'class', scopes: ["text.html.basic", "meta.tag.inline.any.html", "entity.other.attribute-name.html"]
+
   describe "entities", ->
     it "tokenizes & and characters after it", ->
       {tokens} = grammar.tokenizeLine '& &amp; &a'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -88,7 +88,11 @@ describe 'HTML grammar', ->
 
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.coffee.embedded.html']
-      expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'storage.type.function.coffee']
+      # TODO: Remove when Atom 1.22 reaches stable
+      if parseFloat(atom.getVersion()) <= 1.21
+        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'storage.type.function.coffee']
+      else
+        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
 
   describe 'JavaScript script tags', ->
     beforeEach ->

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -106,21 +106,6 @@ describe 'HTML grammar', ->
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.js.embedded.html']
       expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
 
-    it 'detects </script> tags even if they would otherwise be valid JavaScript', ->
-      # This spec relies on language-javascript's "embedded javascript.cson", so if it fails, look there
-      lines = grammar.tokenizeLines '''
-        <script>
-          var test = 'test</script>';
-          var shouldntbematched;
-      '''
-
-      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
-      expect(lines[1][5]).toEqual value: "'", scopes: ['text.html.basic', 'source.js.embedded.html', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
-      expect(lines[1][6]).toEqual value: 'test', scopes: ['text.html.basic', 'source.js.embedded.html', 'string.quoted.single.js']
-      expect(lines[1][7]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
-      expect(lines[1][10]).toEqual value: "';", scopes: ['text.html.basic']
-      expect(lines[2][0]).toEqual value: '  var shouldntbematched;', scopes: ['text.html.basic']
-
   describe "comments", ->
     it "tokenizes -- as an error", ->
       {tokens} = grammar.tokenizeLine '<!-- some comment --->'


### PR DESCRIPTION
The main part of this fix is instead of trying to capture the ending `>` of `<script>` in the `patterns` block, we now explicitly capture it in `beginCaptures`.  To keep the tag tokenization (of things like `id`) from breaking, I moved all the `'include': '#tag-stuff'` parts into `beginCaptures` as well.  Same thing goes for `endCaptures` and the `</` of `</script>`.  In general all that's left in `patterns` is the embedded language.

Also, I didn't see what `(?:\\s*\\n)?` had to do with anything, so I removed it.

Fixes #82

/cc @benogle, @mnquintana
