### PR TITLE
Revamp tag handling

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -14,12 +14,15 @@
 'patterns': [
   {
     'begin': '(<\\?)(xml)'
-    'captures':
+    'beginCaptures':
       '1':
-        'name': 'punctuation.definition.tag.html'
+        'name': 'punctuation.definition.tag.begin.html'
       '2':
         'name': 'entity.name.tag.xml.html'
     'end': '(\\?>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.end.html'
     'name': 'meta.tag.preprocessor.xml.html'
     'patterns': [
       {
@@ -35,10 +38,13 @@
   }
   {
     'begin': '<!--'
-    'captures':
+    'beginCaptures':
       '0':
-        'name': 'punctuation.definition.comment.html'
+        'name': 'punctuation.definition.comment.begin.html'
     'end': '--\\s*>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.end.html'
     'name': 'comment.block.html'
     'patterns': [
       {
@@ -52,10 +58,13 @@
   }
   {
     'begin': '<!'
-    'captures':
+    'beginCaptures':
       '0':
-        'name': 'punctuation.definition.tag.html'
+        'name': 'punctuation.definition.tag.begin.html'
     'end': '>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.tag.end.html'
     'name': 'meta.tag.sgml.html'
     'patterns': [
       {

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -13,30 +13,6 @@
 'name': 'HTML'
 'patterns': [
   {
-    'begin': '(<)([a-zA-Z0-9:-]++)(?=[^>]*></\\2>)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.tag.html'
-      '2':
-        'name': 'entity.name.tag.html'
-    'end': '(>(\\s*<)/)(\\2)(>)'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.definition.tag.html'
-      '2':
-        'name': 'meta.scope.between-tag-pair.html'
-      '3':
-        'name': 'entity.name.tag.html'
-      '4':
-        'name': 'punctuation.definition.tag.html'
-    'name': 'meta.tag.any.html'
-    'patterns': [
-      {
-        'include': '#tag-stuff'
-      }
-    ]
-  }
-  {
     'begin': '(<\\?)(xml)'
     'captures':
       '1':
@@ -312,20 +288,35 @@
     ]
   }
   {
-    'begin': '(</?)([a-zA-Z0-9:-]+)'
+    'begin': '(<)([a-zA-Z0-9:-]+)(.*?)(>)'
     'beginCaptures':
+      '0':
+        'name': 'meta.tag.other.html'
       '1':
         'name': 'punctuation.definition.tag.begin.html'
       '2':
         'name': 'entity.name.tag.other.html'
-    'end': '(>)'
-    'endCaptures':
-      '1':
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
         'name': 'punctuation.definition.tag.end.html'
-    'name': 'meta.tag.other.html'
+    'end': '(</)(\\2)(>)'
+    'endCaptures':
+      '0':
+        'name': 'meta.tag.other.html'
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.other.html'
+      '3':
+        'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
+        'include': '$self'
       }
     ]
   }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -237,53 +237,113 @@
     ]
   }
   {
-    'begin': '(</?)((?i:body|head|html)\\b)'
-    'captures':
+    'begin': '(<)((?i)body|head|html)\\b(.*?)(>)'
+    'beginCaptures':
+      '0':
+        'name': 'meta.tag.structure.any.html'
       '1':
-        'name': 'punctuation.definition.tag.html'
+        'name': 'punctuation.definition.tag.begin.html'
       '2':
         'name': 'entity.name.tag.structure.any.html'
-    'end': '(>)'
-    'name': 'meta.tag.structure.any.html'
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
+        'name': 'punctuation.definition.tag.end.html'
+    'end': '(</)(\\2)(>)'
+    'endCaptures':
+      '0':
+        'name': 'meta.tag.structure.any.html'
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.structure.any.html'
+      '3':
+        'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
+        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
+        'name': 'invalid.illegal.tag.html'
+      }
+      {
+        'include': '$self'
       }
     ]
   }
   {
-    'begin': '(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)\\b)'
+    'begin': '(<)((?i)address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)\\b(.*?)(>)'
     'beginCaptures':
+      '0':
+        'name': 'meta.tag.block.any.html'
       '1':
         'name': 'punctuation.definition.tag.begin.html'
       '2':
         'name': 'entity.name.tag.block.any.html'
-    'end': '(>)'
-    'endCaptures':
-      '1':
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
         'name': 'punctuation.definition.tag.end.html'
-    'name': 'meta.tag.block.any.html'
+    'end': '(</)(\\2)(>)'
+    'endCaptures':
+      '0':
+        'name': 'meta.tag.block.any.html'
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.block.any.html'
+      '3':
+        'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
+        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
+        'name': 'invalid.illegal.tag.html'
+      }
+      {
+        'include': '$self'
       }
     ]
   }
   {
-    'begin': '(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b)'
+    'begin': '(<)((?i)a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b(.*?)(>)'
     'beginCaptures':
+      '0':
+        'name': 'meta.tag.inline.any.html'
       '1':
         'name': 'punctuation.definition.tag.begin.html'
       '2':
         'name': 'entity.name.tag.inline.any.html'
-    'end': '((?: ?/)?>)'
-    'endCaptures':
-      '1':
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
         'name': 'punctuation.definition.tag.end.html'
-    'name': 'meta.tag.inline.any.html'
+    'end': '(</)(\\2)(>)'
+    'endCaptures':
+      '0':
+        'name': 'meta.tag.inline.any.html'
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.inline.any.html'
+      '3':
+        'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
+        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
+        'name': 'invalid.illegal.tag.html'
+      }
+      {
+        'include': '$self'
       }
     ]
   }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -246,44 +246,43 @@
     ]
   }
   {
-    'begin': '(<)((?i)body|head|html)\\b(.*?)(>)'
+    'begin': '(</?)((?i)body|head|html)\\b' # These don't strictly require a closing tag
     'beginCaptures':
-      '0':
-        'name': 'meta.tag.structure.any.html'
       '1':
         'name': 'punctuation.definition.tag.begin.html'
       '2':
         'name': 'entity.name.tag.structure.any.html'
-      '3':
-        'patterns': [
-          {
-            'include': '#tag-stuff'
-          }
-        ]
-      '4':
-        'name': 'punctuation.definition.tag.end.html'
-    'end': '(</)(\\2)(>)'
+    'end': '(>)'
     'endCaptures':
-      '0':
-        'name': 'meta.tag.structure.any.html'
       '1':
         'name': 'punctuation.definition.tag.begin.html'
-      '2':
-        'name': 'entity.name.tag.structure.any.html'
-      '3':
-        'name': 'punctuation.definition.tag.end.html'
+    'name': 'meta.tag.structure.any.html'
     'patterns': [
       {
-        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
-        'name': 'invalid.illegal.tag.html'
-      }
-      {
-        'include': '$self'
+        'include': '#tag-stuff'
       }
     ]
   }
   {
-    'begin': '(<)((?i)address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)\\b(.*?)(>)'
+    'begin': '(</?)((?i)dd|dt|p)\\b' # These don't strictly require a closing tag
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.block.any.html'
+    'end': '(>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.end.html'
+    'name': 'meta.tag.block.any.html'
+    'patterns': [
+      {
+        'include': '#tag-stuff'
+      }
+    ]
+  }
+  {
+    'begin': '(<)((?i)address|blockquote|div|section|article|aside|header|footer|nav|menu|dl|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|ul|applet|center|dir|pre)\\b(.*?)(>)'
     'beginCaptures':
       '0':
         'name': 'meta.tag.block.any.html'
@@ -311,8 +310,7 @@
         'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
-        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
-        'name': 'invalid.illegal.tag.html'
+        'include': '#out-of-order-tags'
       }
       {
         'include': '$self'
@@ -320,7 +318,24 @@
     ]
   }
   {
-    'begin': '(<)((?i)a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b(.*?)(>)'
+    'begin': '(</?)((?i)colgroup|li|optgroup|option|tbody|td|tfoot|th|thead|tr)\\b' # These don't strictly require a closing tag
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.inline.any.html'
+    'end': '(>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.end.html'
+    'patterns': [
+      {
+        'include': '#tag-stuff'
+      }
+    ]
+  }
+  {
+    'begin': '(<)((?i)a|abbr|acronym|b|basefont|bdo|big|button|caption|cite|code|del|dfn|em|font|head|html|i|input|ins|isindex|kbd|label|legend|map|noscript|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|textarea|title|tt|u|var)\\b(.*?)(>)'
     'beginCaptures':
       '0':
         'name': 'meta.tag.inline.any.html'
@@ -348,11 +363,28 @@
         'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
-        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
-        'name': 'invalid.illegal.tag.html'
+        'include': '#out-of-order-tags'
       }
       {
         'include': '$self'
+      }
+    ]
+  }
+  {
+    'begin': '(<)((?i)area|base|br|col|command|embed|hr|img|input|link|meta|param|source)\\b'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.singleton.any.html'
+    'end': '(/?>)' # > (recommended) or />
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.end.html'
+    'name': 'meta.tag.singleton.any.html'
+    'patterns': [
+      {
+        'include': '#tag-stuff'
       }
     ]
   }
@@ -385,8 +417,7 @@
         'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
-        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
-        'name': 'invalid.illegal.tag.html'
+        'include': '#out-of-order-tags'
       }
       {
         'include': '$self'
@@ -425,6 +456,14 @@
       {
         'match': '&'
         'name': 'invalid.illegal.bad-ampersand.html'
+      }
+    ]
+  'out-of-order-tags':
+    'patterns': [
+      {
+        # <a><b></a></b> is invalid, it has to be <a><b></b></a>
+        'match': '</(?!area|base|br|col|colgroup|command|dd|dt|embed|hr|img|input|li|link|meta|optgroup|option|p|param|source|tbody|td|tfoot|th|thead|tr)\\w+>'
+        'name': 'invalid.illegal.out-of-order-tag.html'
       }
     ]
   'python':

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -316,6 +316,10 @@
         'name': 'punctuation.definition.tag.end.html'
     'patterns': [
       {
+        'match': '</\\w+>' # <a><b></a></b> is invalid, it has to be <a><b></b></a>
+        'name': 'invalid.illegal.tag.html'
+      }
+      {
         'include': '$self'
       }
     ]

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -95,3 +95,59 @@ describe 'HTML grammar', ->
       expect(tokens[2]).toEqual value: '--', scopes: ['text.html.basic', 'comment.block.html', 'invalid.illegal.bad-comments-or-CDATA.html']
       expect(tokens[3]).toEqual value: ' ', scopes: ['text.html.basic', 'comment.block.html']
       expect(tokens[4]).toEqual value: '-->', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.end.html']
+
+  describe "tags", ->
+    it "tokenizes them", ->
+      {tokens} = grammar.tokenizeLine '<randomtag attrib="yes">text</randomtag>'
+
+      expect(tokens[0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'randomtag', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[3]).toEqual value: 'attrib', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.other.attribute-name.html']
+      expect(tokens[5]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.other.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[6]).toEqual value: 'yes', scopes: ['text.html.basic', 'meta.tag.other.html', 'string.quoted.double.html']
+      expect(tokens[7]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.other.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[8]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+      expect(tokens[9]).toEqual value: 'text', scopes: ['text.html.basic']
+      expect(tokens[10]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[11]).toEqual value: 'randomtag', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[12]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+
+    it "tokenizes out-of-order tags as invalid", ->
+      {tokens} = grammar.tokenizeLine '<abc><def></abc></def>'
+
+      expect(tokens[0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'abc', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+      expect(tokens[3]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[4]).toEqual value: 'def', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[5]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+      expect(tokens[6]).toEqual value: '</abc>', scopes: ['text.html.basic', 'invalid.illegal.out-of-order-tag.html']
+      expect(tokens[7]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[8]).toEqual value: 'def', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[9]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+
+    it "tokenizes singleton tags", ->
+      {tokens} = grammar.tokenizeLine '<area><hr/>'
+
+      expect(tokens[0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'area', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'entity.name.tag.singleton.any.html']
+      expect(tokens[2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'punctuation.definition.tag.end.html']
+      expect(tokens[3]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[4]).toEqual value: 'hr', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'entity.name.tag.singleton.any.html']
+      expect(tokens[5]).toEqual value: '/>', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'punctuation.definition.tag.end.html']
+
+    it "tokenizes singleton tags as well as tags that don't require a closing tag without marking any following tags as out-of-order", ->
+      {tokens} = grammar.tokenizeLine '<br><b><p></b>'
+
+      expect(tokens[0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'br', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'entity.name.tag.singleton.any.html']
+      expect(tokens[2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.singleton.any.html', 'punctuation.definition.tag.end.html']
+      expect(tokens[3]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[4]).toEqual value: 'b', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html']
+      expect(tokens[5]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html']
+      expect(tokens[6]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.block.any.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[7]).toEqual value: 'p', scopes: ['text.html.basic', 'meta.tag.block.any.html', 'entity.name.tag.block.any.html']
+      expect(tokens[8]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.block.any.html', 'punctuation.definition.tag.end.html']
+      expect(tokens[9]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[10]).toEqual value: 'b', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html']
+      expect(tokens[11]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html']

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -80,17 +80,18 @@ describe 'HTML grammar', ->
       expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.modifier.js']
 
   describe "comments", ->
-    it "tokenizes -- as an error", ->
+    it "tokenizes them", ->
       {tokens} = grammar.tokenizeLine '<!-- some comment --->'
 
-      expect(tokens[0]).toEqual value: '<!--', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.html']
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.begin.html']
       expect(tokens[1]).toEqual value: ' some comment -', scopes: ['text.html.basic', 'comment.block.html']
-      expect(tokens[2]).toEqual value: '-->', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.html']
+      expect(tokens[2]).toEqual value: '-->', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.end.html']
 
+    it "tokenizes -- as an error", ->
       {tokens} = grammar.tokenizeLine '<!-- -- -->'
 
-      expect(tokens[0]).toEqual value: '<!--', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.html']
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.begin.html']
       expect(tokens[1]).toEqual value: ' ', scopes: ['text.html.basic', 'comment.block.html']
       expect(tokens[2]).toEqual value: '--', scopes: ['text.html.basic', 'comment.block.html', 'invalid.illegal.bad-comments-or-CDATA.html']
       expect(tokens[3]).toEqual value: ' ', scopes: ['text.html.basic', 'comment.block.html']
-      expect(tokens[4]).toEqual value: '-->', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.html']
+      expect(tokens[4]).toEqual value: '-->', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.end.html']


### PR DESCRIPTION
This is a fairly large PR, so I'll try to explain it as best as possible:
1. `meta.tag.any.html` has been removed.  This pattern really made absolutely no sense since it was trying to match `<hello></hello>`, but with `meta.scope.between-tag-pair.html` shoved between the `<` and `/`.  It was also trying to match attributes in the text content itself, between the two tags.  Finally, since it was the very first pattern, it was overriding other patterns such as the `script` ones when they were on a single line.
2. `meta.tag.other.html` is basically the replacement for `meta.tag.any.html`, but without its downfalls.  It's a catch-all for any tag that wasn't previously matched.
3. (Most) tag patterns have been updated to match all the way from the opening tag to the closing one.  This way, we can identify out-of-order tags and label them as `invalid.illegal.out-of-order-tag.html` (such as `<abc><def></abc></def>`).
4. Some tag patterns still only match the tag itself.  These patterns are for singleton tags and other tags that don't require a closing tag, such as `p`, `br`, `area`, and more.
5. All tags (including comments) now have appropriate `punctuation.definition.tag.begin.html` (`.comment` for comments) and `.end` selectors.  Previously, it was inconsistent and some had them, while others only had `punctuation.definition.tag.html`.

Note: Please merge after #90.  That PR changed around the script tags and I'd like to make sure that they're consistent with the changes made in this PR before merging this one.

Fixes #25
