### PR TITLE
Improve generic attributes tokenization

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -432,7 +432,7 @@
       }
     ]
   'tag-generic-attribute':
-    'begin': '\\b([a-zA-Z0-9:-]+)\\s*(=)'
+    'begin': '\\b([a-zA-Z0-9:\\-_]+)\\s*(=)'
     'beginCaptures':
       '1':
         'name': 'entity.other.attribute-name.any.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -432,8 +432,25 @@
       }
     ]
   'tag-generic-attribute':
-    'match': '(?<=[^=])\\b([a-zA-Z0-9:-]+)'
-    'name': 'entity.other.attribute-name.html'
+    'begin': '\\b([a-zA-Z0-9:-]+)\\s*(=)'
+    'beginCaptures':
+      '1':
+        'name': 'entity.other.attribute-name.any.html'
+      '2':
+        'name': 'punctuation.separator.key-value.html'
+    'end': '(?<=\'|")|(?=\\s|>)'
+    'name': 'meta.attribute-with-value.html'
+    'patterns': [
+      {
+        'include': '#string-double-quoted'
+      }
+      {
+        'include': '#string-single-quoted'
+      }
+      {
+        'include': '#unquoted-attribute'
+      }
+    ]
   'tag-id-attribute':
     'begin': '\\b(id)\\b\\s*(=)'
     'captures':

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -435,7 +435,7 @@
     'begin': '\\b([a-zA-Z0-9:\\-_]+)\\s*(=)'
     'beginCaptures':
       '1':
-        'name': 'entity.other.attribute-name.any.html'
+        'name': 'entity.other.attribute-name.html'
       '2':
         'name': 'punctuation.separator.key-value.html'
     'end': '(?<=\'|")|(?=\\s|>)'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -79,6 +79,26 @@ describe 'HTML grammar', ->
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.js.embedded.html']
       expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.modifier.js']
 
+  describe "attributes", ->
+    it "tokenizes them", ->
+      {tokens} = grammar.tokenizeLine '<randomtag q="hello" b=true id="no"></randomtag>'
+
+      expect(tokens[2]).toEqual value: ' ', scopes: ['text.html.basic', 'meta.tag.any.html']
+      expect(tokens[3]).toEqual value: 'q', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'entity.other.attribute-name.html']
+      expect(tokens[4]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'punctuation.separator.key-value.html']
+      expect(tokens[5]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[6]).toEqual value: 'hello', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
+      expect(tokens[7]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[9]).toEqual value: 'b', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'entity.other.attribute-name.html']
+      expect(tokens[10]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'punctuation.separator.key-value.html']
+      expect(tokens[11]).toEqual value: 'true', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.html', 'string.unquoted.html']
+      expect(tokens[13]).toEqual value: 'id', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.id.html', 'entity.other.attribute-name.id.html']
+      expect(tokens[14]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.id.html', 'punctuation.separator.key-value.html']
+      expect(tokens[15]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.id.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[16]).toEqual value: 'no', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.id.html', 'string.quoted.double.html', 'meta.toc-list.id.html']
+      expect(tokens[17]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.any.html', 'meta.attribute-with-value.id.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[18]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.any.html', 'punctuation.definition.tag.html']
+
   describe "comments", ->
     it "tokenizes -- as an error", ->
       {tokens} = grammar.tokenizeLine '<!-- some comment --->'


### PR DESCRIPTION
It is now on par with how the `id` attribute is handled, albeit without a special subscope for strings.

Fixes #89
Fixes #91

Please merge after #93 so that I can update only the specs for this one.
