### PR TITLE
let and var are now storage.type.var.js

### DIFF
--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -77,7 +77,7 @@ describe 'HTML grammar', ->
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
 
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.js.embedded.html']
-      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.modifier.js']
+      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
 
   describe "comments", ->
     it "tokenizes -- as an error", ->


### PR DESCRIPTION
Specs are going to fail on Travis because the new language-javascript version hasn't been released yet.

Refs atom/language-javascript#277