### PR TITLE
Added Grammar Test Files for Validating Grammar Rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "devDependencies": {
-    "atom-grammar-test": "^0.1.1",
+    "atom-grammar-test": "^0.1.2",
     "coffeelint": "^1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "devDependencies": {
-    "atom-grammar-test": "^0.1.2",
+    "atom-grammar-test": "^0.3.0",
     "coffeelint": "^1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "devDependencies": {
+    "atom-grammar-test": "^0.1.1",
     "coffeelint": "^1.10.1"
   }
 }

--- a/spec/fixtures/syntax_test_html.html
+++ b/spec/fixtures/syntax_test_html.html
@@ -1,0 +1,29 @@
+<!-- SYNTAX TEST "text.html.basic" -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Test HTML</title>
+        <script><!--
+        <!-- ^ entity.name.tag.script.html -->
+            var foo = 100;
+            var baz = function() {
+            <!-- <- source.js.embedded -->
+            }
+        //--></script>
+        <!-- ^ source.js.embedded.html -->
+        <!--     ^ entity.name.tag.script.html -->
+        <style type="text/css">
+        <!--    ^ entity.other.attribute-name -->
+            h2 {
+            <!-- <- source.css.embedded -->
+                font-family: "Arial";
+            }
+        </style>
+        <!-- ^ entity.name.tag.style.html -->
+        <style />
+    </head>
+    <body>
+        <!-- Comment -->
+        <!-- ^ comment.block.html -->
+    </body>
+</html>

--- a/spec/fixtures/syntax_test_html_template_fragments.html
+++ b/spec/fixtures/syntax_test_html_template_fragments.html
@@ -1,0 +1,40 @@
+<!-- SYNTAX TEST "text.html.basic" -->
+<!DOCTYPE html>
+<html>
+    <body>
+        <!-- Ensure script tags used as html fragments are parsed as embedded html -->
+
+        <script type="text/html" id="myTemplate">
+        <!-- <- punctuation.definition.tag.html -->
+        <!-- ^ entity.name.tag.script.html -->
+            <ul>
+            <!-- <- text.embedded.html -->
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        </script>
+        <!-- <- punctuation.definition.tag.html -->
+
+        <script type="text/ng-template" id="myNgTemplate">
+        <!-- <- punctuation.definition.tag.html -->
+        <!-- ^ entity.name.tag.script.html -->
+            <ul>
+            <!-- <- text.embedded.html -->
+                <li ng-repeat="item in [1, 2, 3]">Item #{$index}</li>
+            </ul>
+        </script>
+        <!-- <- punctuation.definition.tag.html -->
+
+        <script type="text/x-handlebars" id="myHandlebarsTemplate">
+        <!-- <- punctuation.definition.tag.html -->
+        <!-- ^ entity.name.tag.script.html -->
+            <ul>
+            <!-- <- text.embedded.html -->
+            {{#each items}}
+                <li>Item {{@index}}</li>
+            </ul>
+        </script>
+        <!-- <- punctuation.definition.tag.html -->
+    </body>
+</html>

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -1,3 +1,6 @@
+path = require 'path'
+grammarTest = require 'atom-grammar-test'
+
 describe 'HTML grammar', ->
   grammar = null
 
@@ -94,3 +97,6 @@ describe 'HTML grammar', ->
       expect(tokens[2]).toEqual value: '--', scopes: ['text.html.basic', 'comment.block.html', 'invalid.illegal.bad-comments-or-CDATA.html']
       expect(tokens[3]).toEqual value: ' ', scopes: ['text.html.basic', 'comment.block.html']
       expect(tokens[4]).toEqual value: '-->', scopes: ['text.html.basic', 'comment.block.html', 'punctuation.definition.comment.html']
+
+  grammarTest path.join(__dirname, 'fixtures/syntax_test_html.html')
+  grammarTest path.join(__dirname, 'fixtures/syntax_test_html_template_fragments.html')


### PR DESCRIPTION
I recently wrote a package called [atom-grammar-test](https://www.npmjs.com/package/atom-grammar-test) that allows writing grammar tests inline in your example files. Inspired by [ST3's Syntax Test](https://www.sublimetext.com/docs/3/syntax.html#Testing), it greatly helps writing complex cases since you're just annotating inline in your code examples.

I included two examples for HTML to showcase usability, a base case as well as one for
template fragments that was the most recent improvement to support angular templates.  It's much easier to write a regression in this grammar test format compared to either writing jasmine style expects or relying on visual inspection.