### PR TITLE
Remove unsupported attribute

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -199,7 +199,7 @@
     'body': '<li>$1</li>$0'
   'Link':
     'prefix': 'link'
-    'body': '<link rel="${1:stylesheet}" href="${2:/css/master.css}" media="${3:screen}" title="${4:no title}" charset="${5:utf-8}">$0'
+    'body': '<link rel="${1:stylesheet}" href="${2:/css/master.css}" media="${3:screen}" title="${4:no title}">$0'
   # M
   'Main':
     'prefix': 'main'


### PR DESCRIPTION
As of HTML 5, the charset attribute is not supported inside the link tag.

Source: http://www.w3schools.com/tags/att_link_charset.asp