### PR TITLE
Change p tag to one-line style

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -251,7 +251,7 @@
   # P
   'Paragraph':
     'prefix': 'p'
-    'body': '<p>\n\t$1\n</p>'
+    'body': '<p>$1</p>'
   'Parameter':
     'prefix': 'param'
     'body': '<param name="${1:foo}" value="${2:bar}">$0'


### PR DESCRIPTION
#118 @chharvey list of phrased content tags that should not have inline-styles

![p-tag-03](https://cloud.githubusercontent.com/assets/7613470/18260669/831eec06-73b5-11e6-9bdb-57b05e27c1f0.PNG)
![p-tag-04](https://cloud.githubusercontent.com/assets/7613470/18260668/831dbd2c-73b5-11e6-91e6-0af3d3c10a9e.PNG)
