### PR TITLE
Fix misclassification of spec-file on GitHub

### DIFF
--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -197,3 +197,5 @@ describe 'HTML grammar', ->
       """
       for line in invalid.split /\n/
         expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    # -*- coffee -*- # Tell GitHub this isn't an HTML document

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -194,8 +194,7 @@ describe 'HTML grammar', ->
         # vim:noexpandtab sts:4 ft:HTML ts:4
         # vim:noexpandtab titlestring=hi\\|there\\ ft=HTML ts=4
         # vim:noexpandtab titlestring=hi\\|there\\\\\\ ft=HTML ts=4
+        # vim: set ft=coffee ft2=HTML: # Don't change: see atom/language-html#138
       """
       for line in invalid.split /\n/
         expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
-
-    # -*- coffee -*- # Tell GitHub this isn't an HTML document


### PR DESCRIPTION
Linguist scans the [first and last 5 lines](https://github.com/github/linguist/pull/2967) of a file when scanning it for modelines. Currently, it's tripping on the last few Vim modelines, because they're using double-escapes. This PR adds ~~a real modeline~~ **an extra test** to fix both the file's highlighting and its [categorisation in search results](https://github.com/atom/language-html/search?l=html&type=Code).

References: https://github.com/atom/language-javascript/pull/420#issuecomment-250612712.