### PR TITLE
Bumped atom-grammar-test to v0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "dependencies": {
-    "atom-grammar-test": "0.6.0"
+    "atom-grammar-test": "^0.6.3"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
Needed for Atom 1.12+ compatibility due to some ES6 changes.