### PR TITLE
Revert "Revert "Remove custom JavaScript captures""

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -252,21 +252,6 @@
         'end': '(</)((?i:script))'
         'patterns': [
           {
-            'captures':
-              '1':
-                'name': 'punctuation.definition.comment.js'
-            'match': '(//).*?((?=</script)|$\\n?)'
-            'name': 'comment.line.double-slash.js'
-          }
-          {
-            'begin': '/\\*'
-            'captures':
-              '0':
-                'name': 'punctuation.definition.comment.js'
-            'end': '\\*/|(?=</script)'
-            'name': 'comment.block.js'
-          }
-          {
             'include': 'source.js'
           }
         ]

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -82,6 +82,21 @@ describe 'HTML grammar', ->
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.js.embedded.html']
       expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
 
+    it 'detects </script> tags even if they would otherwise be valid JavaScript', ->
+      # This spec relies on language-javascript's "embedded javascript.cson", so if it fails, look there
+      lines = grammar.tokenizeLines '''
+        <script>
+          var test = 'test</script>';
+          var shouldntbematched;
+      '''
+
+      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
+      expect(lines[1][5]).toEqual value: "'", scopes: ['text.html.basic', 'source.js.embedded.html', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
+      expect(lines[1][6]).toEqual value: 'test', scopes: ['text.html.basic', 'source.js.embedded.html', 'string.quoted.single.js']
+      expect(lines[1][7]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
+      expect(lines[1][10]).toEqual value: "';", scopes: ['text.html.basic']
+      expect(lines[2][0]).toEqual value: '  var shouldntbematched;', scopes: ['text.html.basic']
+
   describe "comments", ->
     it "tokenizes -- as an error", ->
       {tokens} = grammar.tokenizeLine '<!-- some comment --->'


### PR DESCRIPTION
Time for the double-revert now that 0.47.1 is out.
Specs should (unfortunately) fail.