### PR TITLE
Fix grammar bug with XML namespaces that are also valid HTML tags and tag names that start with a valid HTML tag before a hyphen

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -329,7 +329,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:body|head|html)\\b)'
+    'begin': '(</?)((?i:body|head|html)(?!:)\\b)'
     'captures':
       '1':
         'name': 'punctuation.definition.tag.html'
@@ -344,7 +344,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)\\b)'
+    'begin': '(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)(?!:)\\b)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'
@@ -362,7 +362,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b)'
+    'begin': '(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)(?!:)\\b)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -329,7 +329,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:body|head|html)(?![:-])\\b)'
+    'begin': '(</?)((?i:body|head|html)(?=\\s|/?>))'
     'captures':
       '1':
         'name': 'punctuation.definition.tag.html'
@@ -344,7 +344,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)(?![:-])\\b)'
+    'begin': '(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)(?=\\s|/?>))'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'
@@ -362,7 +362,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)(?![:-])\\b)'
+    'begin': '(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)(?=\\s|/?>))'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -329,7 +329,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:body|head|html)(?!:)\\b)'
+    'begin': '(</?)((?i:body|head|html)(?![:-])\\b)'
     'captures':
       '1':
         'name': 'punctuation.definition.tag.html'
@@ -344,7 +344,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)(?!:)\\b)'
+    'begin': '(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)(?![:-])\\b)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'
@@ -362,7 +362,7 @@
     ]
   }
   {
-    'begin': '(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)(?!:)\\b)'
+    'begin': '(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)(?![:-])\\b)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -418,15 +418,15 @@ describe 'HTML grammar', ->
   describe "tags", ->
     it "tokenizes style tags as such", ->
       lines = grammar.tokenizeLines '<style>'
-      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'source.css.embedded.html', 'punctuation.definition.tag.html']
-      expect(lines[0][1]).toEqual value: 'style', scopes: ['text.html.basic', 'source.css.embedded.html', 'entity.name.tag.style.html']
-      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'source.css.embedded.html', 'punctuation.definition.tag.html']
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.style.html', 'punctuation.definition.tag.html']
+      expect(lines[0][1]).toEqual value: 'style', scopes: ['text.html.basic', 'meta.tag.style.html', 'entity.name.tag.style.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.style.html', 'punctuation.definition.tag.html']
 
     it "tokenizes script tags as such", ->
       lines = grammar.tokenizeLines '<script>'
-      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
-      expect(lines[0][1]).toEqual value: 'script', scopes: ['text.html.basic', 'entity.name.tag.script.html']
-      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'source.js.embedded.html', 'punctuation.definition.tag.html']
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+      expect(lines[0][1]).toEqual value: 'script', scopes: ['text.html.basic', 'meta.tag.script.html', 'entity.name.tag.script.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
 
     it "tokenizes structure tags as such", ->
       lines = grammar.tokenizeLines '<html>'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -449,52 +449,52 @@ describe 'HTML grammar', ->
     it "doesn't tokenize XML namespaces as tags if the prefix is a valid style tag", ->
       lines = grammar.tokenizeLines '<style:foo>'
       expect(lines[0][1].value).toNotEqual 'style'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.style.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "doesn't tokenize XML namespaces as tags if the prefix is a valid script tag", ->
       lines = grammar.tokenizeLines '<script:foo>'
       expect(lines[0][1].value).toNotEqual 'script'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.script.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "doesn't tokenize XML namespaces as tags if the prefix is a valid structure tag", ->
       lines = grammar.tokenizeLines '<html:foo>'
       expect(lines[0][1].value).toNotEqual 'html'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.structure.any.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "doesn't tokenize XML namespaces as tags if the prefix is a valid block tag", ->
       lines = grammar.tokenizeLines '<div:foo>'
       expect(lines[0][1].value).toNotEqual 'div'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.block.any.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "doesn't tokenize XML namespaces as tags if the prefix is a valid inline tag", ->
       lines = grammar.tokenizeLines '<span:foo>'
       expect(lines[0][1].value).toNotEqual 'span'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.inline.any.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid style tag", ->
       lines = grammar.tokenizeLines '<style-foo>'
       expect(lines[0][1].value).toNotEqual 'style'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.style.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid script tag", ->
       lines = grammar.tokenizeLines '<script-foo>'
       expect(lines[0][1].value).toNotEqual 'script'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.script.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid structure tag", ->
       lines = grammar.tokenizeLines '<html-foo>'
       expect(lines[0][1].value).toNotEqual 'html'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.structure.any.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid block tag", ->
       lines = grammar.tokenizeLines '<div-foo>'
       expect(lines[0][1].value).toNotEqual 'div'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.block.any.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid inline tag", ->
       lines = grammar.tokenizeLines '<span-foo>'
       expect(lines[0][1].value).toNotEqual 'span'
-      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.inline.any.html'
+      expect(lines[0][1].scopes).toEqual ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
 
     it "tokenizes other tags as such", ->
       lines = grammar.tokenizeLines '<foo>'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -471,6 +471,31 @@ describe 'HTML grammar', ->
       expect(lines[0][1].value).toNotEqual 'span'
       expect(lines[0][1].scopes).not.toContain 'entity.name.tag.inline.any.html'
 
+    it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid style tag", ->
+      lines = grammar.tokenizeLines '<style-foo>'
+      expect(lines[0][1].value).toNotEqual 'style'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.style.html'
+
+    it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid script tag", ->
+      lines = grammar.tokenizeLines '<script-foo>'
+      expect(lines[0][1].value).toNotEqual 'script'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.script.html'
+
+    it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid structure tag", ->
+      lines = grammar.tokenizeLines '<html-foo>'
+      expect(lines[0][1].value).toNotEqual 'html'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.structure.any.html'
+
+    it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid block tag", ->
+      lines = grammar.tokenizeLines '<div-foo>'
+      expect(lines[0][1].value).toNotEqual 'div'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.block.any.html'
+
+    it "it doesn't treat only the part before a hyphen as tag name if this part is a is a valid inline tag", ->
+      lines = grammar.tokenizeLines '<span-foo>'
+      expect(lines[0][1].value).toNotEqual 'span'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.inline.any.html'
+
     it "tokenizes other tags as such", ->
       lines = grammar.tokenizeLines '<foo>'
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
@@ -480,3 +505,7 @@ describe 'HTML grammar', ->
     it "tolerates colons in other tag names", ->
       lines = grammar.tokenizeLines '<foo:bar>'
       expect(lines[0][1]).toEqual value: 'foo:bar', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+
+    it "tolerates hyphens in other tag names", ->
+      lines = grammar.tokenizeLines '<foo-bar>'
+      expect(lines[0][1]).toEqual value: 'foo-bar', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -414,3 +414,69 @@ describe 'HTML grammar', ->
       """
       for line in invalid.split /\n/
         expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+  describe "tags", ->
+    it "tokenizes style tags as such", ->
+      lines = grammar.tokenizeLines '<style>'
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'source.css.embedded.html', 'punctuation.definition.tag.html']
+      expect(lines[0][1]).toEqual value: 'style', scopes: ['text.html.basic', 'source.css.embedded.html', 'entity.name.tag.style.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'source.css.embedded.html', 'punctuation.definition.tag.html']
+
+    it "tokenizes script tags as such", ->
+      lines = grammar.tokenizeLines '<script>'
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
+      expect(lines[0][1]).toEqual value: 'script', scopes: ['text.html.basic', 'entity.name.tag.script.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'source.js.embedded.html', 'punctuation.definition.tag.html']
+
+    it "tokenizes structure tags as such", ->
+      lines = grammar.tokenizeLines '<html>'
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.structure.any.html', 'punctuation.definition.tag.html']
+      expect(lines[0][1]).toEqual value: 'html', scopes: ['text.html.basic', 'meta.tag.structure.any.html', 'entity.name.tag.structure.any.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.structure.any.html', 'punctuation.definition.tag.html']
+
+    it "tokenizes block tags as such", ->
+      lines = grammar.tokenizeLines '<div>'
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.block.any.html', 'punctuation.definition.tag.begin.html']
+      expect(lines[0][1]).toEqual value: 'div', scopes: ['text.html.basic', 'meta.tag.block.any.html', 'entity.name.tag.block.any.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.block.any.html', 'punctuation.definition.tag.end.html']
+
+    it "tokenizes inline tags as such", ->
+      lines = grammar.tokenizeLines '<span>'
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html']
+      expect(lines[0][1]).toEqual value: 'span', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html']
+
+    it "dosn't tokenize XML namespaces as tags if the prefix is a valid style tags", ->
+      lines = grammar.tokenizeLines '<style:foo>'
+      expect(lines[0][1].value).toNotEqual 'style'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.style.html'
+
+    it "dosn't tokenize XML namespaces as tags if the prefix is a valid script tags", ->
+      lines = grammar.tokenizeLines '<script:foo>'
+      expect(lines[0][1].value).toNotEqual 'script'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.script.html'
+
+    it "dosn't tokenize XML namespaces as tags if the prefix is a valid structure tags", ->
+      lines = grammar.tokenizeLines '<html:foo>'
+      expect(lines[0][1].value).toNotEqual 'html'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.structure.any.html'
+
+    it "dosn't tokenize XML namespaces as tags if the prefix is a valid block tags", ->
+      lines = grammar.tokenizeLines '<div:foo>'
+      expect(lines[0][1].value).toNotEqual 'div'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.block.any.html'
+
+    it "dosn't tokenize XML namespaces as tags if the prefix is a valid inline tags", ->
+      lines = grammar.tokenizeLines '<span:foo>'
+      expect(lines[0][1].value).toNotEqual 'span'
+      expect(lines[0][1].scopes).not.toContain 'entity.name.tag.inline.any.html'
+
+    it "tokenizes other tags as such", ->
+      lines = grammar.tokenizeLines '<foo>'
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(lines[0][1]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+
+    it "tolerates colons in other tag names", ->
+      lines = grammar.tokenizeLines '<foo:bar>'
+      expect(lines[0][1]).toEqual value: 'foo:bar', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -446,27 +446,27 @@ describe 'HTML grammar', ->
       expect(lines[0][1]).toEqual value: 'span', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html']
       expect(lines[0][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html']
 
-    it "dosn't tokenize XML namespaces as tags if the prefix is a valid style tags", ->
+    it "doesn't tokenize XML namespaces as tags if the prefix is a valid style tag", ->
       lines = grammar.tokenizeLines '<style:foo>'
       expect(lines[0][1].value).toNotEqual 'style'
       expect(lines[0][1].scopes).not.toContain 'entity.name.tag.style.html'
 
-    it "dosn't tokenize XML namespaces as tags if the prefix is a valid script tags", ->
+    it "doesn't tokenize XML namespaces as tags if the prefix is a valid script tag", ->
       lines = grammar.tokenizeLines '<script:foo>'
       expect(lines[0][1].value).toNotEqual 'script'
       expect(lines[0][1].scopes).not.toContain 'entity.name.tag.script.html'
 
-    it "dosn't tokenize XML namespaces as tags if the prefix is a valid structure tags", ->
+    it "doesn't tokenize XML namespaces as tags if the prefix is a valid structure tag", ->
       lines = grammar.tokenizeLines '<html:foo>'
       expect(lines[0][1].value).toNotEqual 'html'
       expect(lines[0][1].scopes).not.toContain 'entity.name.tag.structure.any.html'
 
-    it "dosn't tokenize XML namespaces as tags if the prefix is a valid block tags", ->
+    it "doesn't tokenize XML namespaces as tags if the prefix is a valid block tag", ->
       lines = grammar.tokenizeLines '<div:foo>'
       expect(lines[0][1].value).toNotEqual 'div'
       expect(lines[0][1].scopes).not.toContain 'entity.name.tag.block.any.html'
 
-    it "dosn't tokenize XML namespaces as tags if the prefix is a valid inline tags", ->
+    it "doesn't tokenize XML namespaces as tags if the prefix is a valid inline tag", ->
       lines = grammar.tokenizeLines '<span:foo>'
       expect(lines[0][1].value).toNotEqual 'span'
       expect(lines[0][1].scopes).not.toContain 'entity.name.tag.inline.any.html'


### PR DESCRIPTION
### Description of the Change

Using XML namespaces in HTML is generally tolerated by the grammar even though it's not valid HTML. For this reason the `begin` regex in line 328 contains a colon. However when using a namespace that is also a valid HTML tag, this rule won't apply and instead a rule for a HTML tag specific scope like `meta.tag.inline.any.html` will apply and only capture the namespace as tag name and capture the actual tag name as attribute. This PR adds a lookbehind after the regexes for specific HTML tags to make sure only
actual tag names are captured and no namespaces.
This PR also adds specs for this behavior.

Before this PR, this:
```
<div:foo>
```
would be falsely tokenized as:
* `<`: `text.html.basic`, `meta.tag.block.any.html`, `punctuation.definition.tag.begin.html`
* `div`: `text.html.basic`, `meta.tag.block.any.html`, `entity.name.tag.block.any.html`
* `:foo`: `text.html.basic`, `meta.tag.block.any.html`, `entity.other.attribute-name.html`
* `>`: `text.html.basic`, `meta.tag.block.any.html`, `punctuation.definition.tag.end.html`

Now it will be tokenized as just:
* `<`: `text.html.basic`, `meta.tag.block.any.html`, `punctuation.definition.tag.begin.html`
* `div:foo`: `text.html.basic`, `meta.tag.other.html`, `entity.name.tag.other.html`
* `>`: `text.html.basic`, `meta.tag.block.any.html`, `punctuation.definition.tag.end.html`


### Alternate Designs
- None

### Benefits
- This fixes a problem with the [JSP Grammar](https://github.com/atom/language-java/blob/master/grammars/java%20server%20pages%20(jsp).cson) which is based on the HTML grammar. JSP allows custom tags which are written as `<ns:tag>` and if the namespace is for example `a`, this caused problems.

### Possible Drawbacks
- I am aware of none

### Applicable Issues
- I am aware of none