### PR TITLE
Correct indentation of `html` snippet to match auto indent

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -159,7 +159,7 @@
     'body': '<hr>'
   'HTML':
     'prefix': 'html'
-    'body': '<!DOCTYPE html>\n<html>\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$1</title>\n\t</head>\n\t<body>\n\t\t$2\n\t</body>\n</html>'
+    'body': '<!DOCTYPE html>\n<html>\n<head>\n\t<meta charset="utf-8">\n\t<title>$1</title>\n</head>\n<body>\n\t$2\n</body>\n</html>'
   # I
   'Italic':
     'prefix': 'i'


### PR DESCRIPTION
### Description of the Change

This PR deals with this package's `html` snippet (the one that expands to a basic HTML document). I noticed that the way the `head` and `body` tags are indented is inconsistent with how Atom auto-indents the code when you run the `Editor: Auto Indent` command. This PR reduces the indentation of the `html` snippet to match what auto-indent would do.

**Expanded contents of `html` snippet:**  
![screen shot 2017-01-17 at 10 26 49 am](https://cloud.githubusercontent.com/assets/872474/22034218/625abe9c-dca0-11e6-8078-53729327d725.png)

**Contents after auto-indent (and the proposed snippet contents):**
![screen shot 2017-01-17 at 10 27 23 am](https://cloud.githubusercontent.com/assets/872474/22034220/65b5b66e-dca0-11e6-8e1e-a6dd53f2f810.png)

I don't think any additional tests are needed for a simple change in snippet indentation.

### Alternate Designs

You could look at fixing this inconsistency from the opposite angle—changing the auto indent behavior to reflect the current indentation for this snippet. However, that approach seems to me a bit overkill, and I'd much prefer the flatter nesting of the auto indent.

### Benefits

- Consistency with the current behavior of auto-indent

### Possible Drawbacks

No practical drawbacks, really.

### Applicable Issues

None, and all tests are still passing!
