### PR TITLE
Fix backreference

### DIFF
--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -7,7 +7,7 @@
       <(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\\b|[^>]*/>)
       ([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*</\\1>)
       |<!--(?!.*-->)
-      |<\\?php.+?\\b(if|else(?:if)?|for(?:each)?|while)\\b.*:(?!.*end\\1)
+      |<\\?php.+?\\b(if|else(?:if)?|for(?:each)?|while)\\b.*:(?!.*end\\2)
       |\\{[^}"\']*$
     '''
     'decreaseIndentPattern': '''(?x)


### PR DESCRIPTION
This error is not apparent because of indent pattern algorithm implemented in Atom, but it should be 2 as 1 refers to the first alternative which is HTML tag syntax.