### PR TITLE
Improve entity scopes, take two

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -648,7 +648,7 @@
   'unquoted-attribute':
     'patterns': [
       {
-        'include': '#entities'
+        'include': '#attribute-entities'
       }
       {
         # https://www.w3.org/TR/html51/syntax.html#attribute-value-unquoted-state

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -416,7 +416,7 @@
       }
     ]
   'text-entities':
-    # https://www.w3.org/TR/html5/syntax.html#consume-a-character-reference
+    # https://www.w3.org/TR/html51/syntax.html#consume-a-character-reference
     'patterns': [
       {
         'begin': '(&)([a-zA-Z0-9]+|#\\d+|#[xX][0-9a-fA-F]+)'
@@ -437,7 +437,7 @@
       }
     ]
   'attribute-entities':
-    # https://www.w3.org/TR/html5/syntax.html#consume-a-character-reference
+    # https://www.w3.org/TR/html51/syntax.html#consume-a-character-reference
     # Because it would be infeasible to include the entire list of allowed entities,
     # make sure that an equals sign or the end of a string does not follow a potential reference.
     'patterns': [

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -364,7 +364,7 @@
     # https://www.w3.org/TR/html5/syntax.html#consume-a-character-reference
     'patterns': [
       {
-        'begin': '(&)([a-zA-Z0-9]+|#\\d+|#[xX]\\h+)'
+        'begin': '(&)([a-zA-Z0-9]+|#\\d+|#[xX][0-9a-fA-F]+)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.entity.begin.html'
@@ -387,7 +387,7 @@
     # make sure that an equals sign or the end of a string does not follow a potential reference.
     'patterns': [
       {
-        'begin': '(&)(#\\d+|#[xX]\\h+)'
+        'begin': '(&)(#\\d+|#[xX][0-9a-fA-F]+)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.entity.begin.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -343,7 +343,7 @@
     ]
   }
   {
-    'include': '#entities'
+    'include': '#text-entities'
   }
   {
     'match': '<>'
@@ -360,21 +360,61 @@
         'include': '#python'
       }
     ]
-  'entities':
+  'text-entities':
+    # https://www.w3.org/TR/html5/syntax.html#consume-a-character-reference
     'patterns': [
       {
-        'match': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)'
-        'captures':
+        'begin': '(&)([a-zA-Z0-9]+|#\\d+|#[xX]\\h+)'
+        'beginCaptures':
           '1':
             'name': 'punctuation.definition.entity.begin.html'
           '2':
             'name': 'entity.name.entity.other.html'
-          '3':
+        'end': ';'
+        'endCaptures':
+          '0':
             'name': 'punctuation.definition.entity.end.html'
         'name': 'constant.character.entity.html'
       }
       {
-        'match': '&'
+        'match': '&(?!\\s|<|&)'
+        'name': 'invalid.illegal.bad-ampersand.html'
+      }
+    ]
+  'attribute-entities':
+    # https://www.w3.org/TR/html5/syntax.html#consume-a-character-reference
+    # Because it would be infeasible to include the entire list of allowed entities,
+    # make sure that an equals sign or the end of a string does not follow a potential reference.
+    'patterns': [
+      {
+        'begin': '(&)(#\\d+|#[xX]\\h+)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.entity.begin.html'
+          '2':
+            'name': 'entity.name.entity.other.html'
+        'end': ';'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.entity.end.html'
+        'name': 'constant.character.entity.html'
+      }
+      {
+        'begin': '(&)([a-zA-Z0-9]++)(?!["\'=])'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.entity.begin.html'
+          '2':
+            'name': 'entity.name.entity.other.html'
+        'end': ';'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.entity.end.html'
+        'name': 'constant.character.entity.html'
+      }
+      {
+        # In attributes, potential references that end with an equals sign are fine
+        'match': '&(?!\\s|<|&|[a-zA-Z0-9]+=)'
         'name': 'invalid.illegal.bad-ampersand.html'
       }
     ]
@@ -425,7 +465,7 @@
         'include': '#embedded-code'
       }
       {
-        'include': '#entities'
+        'include': '#attribute-entities'
       }
     ]
   'string-single-quoted':
@@ -443,7 +483,7 @@
         'include': '#embedded-code'
       }
       {
-        'include': '#entities'
+        'include': '#attribute-entities'
       }
     ]
   'tag-generic-attribute':
@@ -475,7 +515,7 @@
             'include': '#embedded-code'
           }
           {
-            'include': '#entities'
+            'include': '#attribute-entities'
           }
         ]
       }
@@ -495,7 +535,7 @@
             'include': '#embedded-code'
           }
           {
-            'include': '#entities'
+            'include': '#attribute-entities'
           }
         ]
       }

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -424,28 +424,28 @@ describe 'HTML grammar', ->
   describe "entities in attributes", ->
     it "tokenizes entities", ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&amp;">'
-      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.begin.html']
-      expect(tokens[8]).toEqual value: 'amp', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'constant.character.entity.html', 'entity.name.entity.other.html']
-      expect(tokens[9]).toEqual value: ';', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.end.html']
+      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.begin.html']
+      expect(tokens[8]).toEqual value: 'amp', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'constant.character.entity.html', 'entity.name.entity.other.html']
+      expect(tokens[9]).toEqual value: ';', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.end.html']
 
     it "does not tokenize query parameters as entities", ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?one=1&type=json&topic=css">'
-      expect(tokens[6]).toEqual value: 'http://example.com?one=1&type=json&topic=css', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html']
+      expect(tokens[6]).toEqual value: 'http://example.com?one=1&type=json&topic=css', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
 
     it "tokenizes invalid ampersands", ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&">'
-      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']
+      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']
 
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&=">'
-      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']
+      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']
 
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?& ">'
-      expect(tokens[6]).toEqual value: 'http://example.com?& ', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html']
+      expect(tokens[6]).toEqual value: 'http://example.com?& ', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
 
       # Note: in order to replicate this test's behavior, make sure you have language-hyperlink disabled
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&&">'
-      expect(tokens[6]).toEqual value: 'http://example.com?&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html']
-      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']
+      expect(tokens[6]).toEqual value: 'http://example.com?&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
+      expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']
 
   describe "firstLineMatch", ->
     it "recognises HTML5 doctypes", ->

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -387,6 +387,9 @@ describe 'HTML grammar', ->
       expect(tokens[5]).toEqual value: '&', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.begin.html']
       expect(tokens[6]).toEqual value: 'a', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
 
+      lines = grammar.tokenizeLines '&\n'
+      expect(lines[0][0]).toEqual value: '&', scopes: ['text.html.basic']
+
     it "tokenizes hexadecimal and digit entities", ->
       {tokens} = grammar.tokenizeLine '&#x00022; &#X00022; &#34;'
 
@@ -433,6 +436,7 @@ describe 'HTML grammar', ->
       expect(tokens[6]).toEqual value: 'http://example.com?one=1&type=json&topic=css', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
 
     it "tokenizes invalid ampersands", ->
+      # Note: in order to replicate the following tests' behaviors, make sure you have language-hyperlink disabled
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&">'
       expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']
 
@@ -442,7 +446,9 @@ describe 'HTML grammar', ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?& ">'
       expect(tokens[6]).toEqual value: 'http://example.com?& ', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
 
-      # Note: in order to replicate this test's behavior, make sure you have language-hyperlink disabled
+      lines = grammar.tokenizeLines '<a href="http://example.com?&\n">'
+      expect(lines[0][6]).toEqual value: 'http://example.com?&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
+
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&&">'
       expect(tokens[6]).toEqual value: 'http://example.com?&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
       expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.any.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Redo of #98, this time taking into account that entities in attributes behave differently.  I tried to follow [the spec](https://www.w3.org/TR/html5/syntax.html#consume-a-character-reference) as closely as possible.

### Alternate Designs

* The list of valid entities could be included.  I'd rather not do that though.
* Single-line matches before the begin/end pattern removes the potential for runaway rules, but means that all entities will appear as invalid before they are finished.

### Benefits

Realize you're writing an entity before you finish doing so.  This also benefits autocomplete-html.

### Possible Drawbacks

There may still be room for regressions that I didn't take into account.

### Applicable Issues

See #98, #141, #142.

/cc @DavidePastore, @JonathanWolfe - see anything that could potentially break with this version?