### PR TITLE
Fix php closing braces indent

### DIFF
--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -15,7 +15,7 @@
       (</(?!html)
         [-_\\.A-Za-z0-9]+\\b[^>]*>
         |-->
-        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while)\\})
+        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while)|\\})
         |\\}
       )
     '''

--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -15,7 +15,7 @@
       (</(?!html)
         [-_\\.A-Za-z0-9]+\\b[^>]*>
         |-->
-        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while))
+        |<\\?(php)?\\s+(else(if)?|end(if|for(each)?|while)\\})
         |\\}
       )
     '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

There is more than one syntax for inline php as shown in the [PHP page](http://php.net/manual/en/control-structures.alternative-syntax.php)


The auto-indent currently works for this syntax of inline php:
```
<?php if ($cond) : ?>
    some-html-here
<?php endif; ?>
```
but when trying this other syntax the indentation breaks:
```
<?php if ($cond) { ?>
    some-html-here
    <?php } ?>
```
So I just added `<?php }` to the decreaseIndentPattern to make it properly align.

### Alternate Designs

I chose this approach because the indentation rules for the alternate syntax were already managed in this variable and it was simply a matter of placing it in the regex.

### Benefits

Another syntax of inline php will indent correctly.

### Possible Drawbacks

All lines starting with `<?php }` will decrease indent.

### Applicable Issues

I couldn't find any Issue regarding this.
