### PR TITLE
Fix highlighting for attributes after newline

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -447,7 +447,7 @@
       }
     ]
   'tag-generic-attribute':
-    'match': '(?<=[^=])\\b([a-zA-Z0-9:-]+)'
+    'match': '(?<=[^=]|^)\\b([a-zA-Z0-9:-]+)'
     'name': 'entity.other.attribute-name.html'
   'tag-id-attribute':
     'begin': '\\b(id)\\b\\s*(=)'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -447,7 +447,7 @@
       }
     ]
   'tag-generic-attribute':
-    'match': '(?<=[^=]|^)\\b([a-zA-Z0-9:-]+)'
+    'match': '(?<!=)\\b([a-zA-Z0-9:-]+)'
     'name': 'entity.other.attribute-name.html'
   'tag-id-attribute':
     'begin': '\\b(id)\\b\\s*(=)'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -102,9 +102,9 @@ describe 'HTML grammar', ->
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html_template_fragments.html')
 
   describe "attributes", ->
-     it "recognizes attributes", ->
-        lines = grammar.tokenizeLines '<span\nclass="foo">'
-        expect(lines[1][0]).toEqual value: 'class', scopes: ["text.html.basic", "meta.tag.inline.any.html", "entity.other.attribute-name.html"]
+    it "recognizes attributes", ->
+      lines = grammar.tokenizeLines '<span\nclass="foo">'
+      expect(lines[1][0]).toEqual value: 'class', scopes: ["text.html.basic", "meta.tag.inline.any.html", "entity.other.attribute-name.html"]
 
   describe "entities", ->
     it "tokenizes & and characters after it", ->

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -101,6 +101,11 @@ describe 'HTML grammar', ->
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html.html')
   grammarTest path.join(__dirname, 'fixtures/syntax_test_html_template_fragments.html')
 
+  describe "attributes", ->
+     it "recognizes attributes", ->
+        lines = grammar.tokenizeLines '<span\nclass="foo">'
+        expect(lines[1][0]).toEqual value: 'class', scopes: ["text.html.basic", "meta.tag.inline.any.html", "entity.other.attribute-name.html"]
+
   describe "entities", ->
     it "tokenizes & and characters after it", ->
       {tokens} = grammar.tokenizeLine '& &amp; &a'


### PR DESCRIPTION
### Description of the Change

This addresses issue #157.  Includes a small change to `tag-generic-attribute` regular expression and a corresponding unit test.  
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Not aware of an alternate design.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Better highlighting of html attributes.  
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Add more complexity to the grammar.  However, does not break anything in the spec.  
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
