### PR TITLE
Fix improper tokenization of script tags

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -247,7 +247,7 @@
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.coffee'
-            'end': '###|(?=</script>)'
+            'end': '###|(?=(?i)</script>)'
             'endCaptures':
               '0':
                 'name': 'punctuation.definition.comment.coffee'
@@ -258,7 +258,7 @@
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.coffee'
-            'end': '(?=</script>|$)'
+            'end': '(?=(?i)</script>|$)'
             'name': 'comment.line.number-sign.coffee'
           }
           {
@@ -307,7 +307,7 @@
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.js'
-            'end': '(?=</script>|$)'
+            'end': '(?=(?i)</script>|$)'
             'name': 'comment.line.double-slash.js'
           }
           {
@@ -315,7 +315,7 @@
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.begin.js'
-            'end': '\\*/|(?=</script)'
+            'end': '\\*/|(?=(?i)</script)'
             'endCaptures':
               '0':
                 'name': 'punctuation.definition.comment.begin.js'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -201,7 +201,7 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)script)\\b(\\s+.*?\\btype\\s*=\\s*[\'"]?text/coffeescript[\'"]?.*?)(>)'
+    'begin': '(?:^\\s+)?(<)((?i)script)(\\s+.*?\\btype\\s*=\\s*[\'"]?text/coffeescript[\'"]?.*?)(>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -124,21 +124,8 @@
     'include': '#embedded-code'
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)style)(\\s+.*)?\\s*(>)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.tag.html'
-      '2':
-        'name': 'entity.name.tag.style.html'
-      '3':
-        'patterns': [
-          {
-            'include': '#tag-stuff'
-          }
-        ]
-      '4':
-        'name': 'punctuation.definition.tag.html'
-    'end': '(</)((?i)style)(>)'
+    'begin': '(?i)(?=<style(\\s+|>))'
+    'end': '(?i)(</)(style)(>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'
@@ -147,11 +134,28 @@
       '3':
         'name': 'punctuation.definition.tag.html'
     'name': 'meta.tag.style.html'
-    'contentName': 'source.css.embedded.html'
     'patterns': [
       {
-        'begin': '\\G'
-        'end': '(?=</(?i:style)>)'
+        'begin': '(?i)\\G(<)(style)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.tag.html'
+          '2':
+            'name': 'entity.name.tag.style.html'
+        'end': '>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.tag.html'
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      }
+      {
+        'begin': '(?!\\G)'
+        'end': '(?i)(?=</style>)'
+        'name': 'source.css.embedded.html'
         'patterns': [
           {
             'include': '#embedded-code'
@@ -164,20 +168,7 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)script)(\\s+.*?\\btype\\s*=\\s*[\'"]?text/(?:x-handlebars|(?:x-(?:handlebars-)?|ng-)?template|html)[\'"]?.*?)(>)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.tag.html'
-      '2':
-        'name': 'entity.name.tag.script.html'
-      '3':
-        'patterns': [
-          {
-            'include': '#tag-stuff'
-          }
-        ]
-      '4':
-        'name': 'punctuation.definition.tag.html'
+    'begin': '(?i)(?=<script\\s+.*?\\btype\\s*=\\s*[\'"]?text/(?:x-handlebars|(?:x-(?:handlebars-)?|ng-)?template|html)[\'"]?(\\s+|>))'
     'end': '(</)((?i)script)(>)'
     'endCaptures':
       '1':
@@ -187,11 +178,28 @@
       '3':
         'name': 'punctuation.definition.tag.html'
     'name': 'meta.tag.script.html'
-    'contentName': 'text.embedded.html'
     'patterns': [
       {
-        'begin': '\\G'
-        'end': '(?=</(?i:script)>)'
+        'begin': '(?i)\\G(<)(script)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.tag.html'
+          '2':
+            'name': 'entity.name.tag.script.html'
+        'end': '>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.tag.html'
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      }
+      {
+        'begin': '(?!\\G)'
+        'end': '(?i)(?=</script>)'
+        'name': 'text.embedded.html'
         'patterns': [
           {
             'include': 'text.html.basic'
@@ -201,20 +209,7 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)script)(\\s+.*?\\btype\\s*=\\s*[\'"]?text/coffeescript[\'"]?.*?)(>)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.tag.html'
-      '2':
-        'name': 'entity.name.tag.script.html'
-      '3':
-        'patterns': [
-          {
-            'include': '#tag-stuff'
-          }
-        ]
-      '4':
-        'name': 'punctuation.definition.tag.html'
+    'begin': '(?i)(?=<script\\s+.*?\\btype\\s*=\\s*[\'"]?text/coffeescript[\'"]?(\\s+|>))'
     'end': '(</)((?i)script)(>)'
     'endCaptures':
       '1':
@@ -224,11 +219,28 @@
       '3':
         'name': 'punctuation.definition.tag.html'
     'name': 'meta.tag.script.html'
-    'contentName': 'source.coffee.embedded.html'
     'patterns': [
       {
-        'begin': '\\G'
-        'end': '(?=</(?i:script)>)'
+        'begin': '(?i)\\G(<)(script)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.tag.html'
+          '2':
+            'name': 'entity.name.tag.script.html'
+        'end': '>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.tag.html'
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      }
+      {
+        'begin': '(?!\\G)'
+        'end': '(?i)(?=</script>)'
+        'name': 'source.coffee.embedded.html'
         'patterns': [
           {
             'begin': '###'
@@ -236,6 +248,9 @@
               '0':
                 'name': 'punctuation.definition.comment.coffee'
             'end': '###|(?=</script>)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.coffee'
             'name': 'comment.block.coffee'
           }
           {
@@ -254,20 +269,7 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i)script)(\\s+.*?)?(>)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.tag.html'
-      '2':
-        'name': 'entity.name.tag.script.html'
-      '3':
-        'patterns': [
-          {
-            'include': '#tag-stuff'
-          }
-        ]
-      '4':
-        'name': 'punctuation.definition.tag.html'
+    'begin': '(?i)(?=<script(\\s+|>))'
     'end': '(</)((?i)script)(>)'
     'endCaptures':
       '1':
@@ -277,11 +279,28 @@
       '3':
         'name': 'punctuation.definition.tag.html'
     'name': 'meta.tag.script.html'
-    'contentName': 'source.js.embedded.html'
     'patterns': [
       {
-        'begin': '\\G'
-        'end': '(?=</(?i:script)>)'
+        'begin': '(?i)\\G(<)(script)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.tag.html'
+          '2':
+            'name': 'entity.name.tag.script.html'
+        'end': '>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.tag.html'
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      }
+      {
+        'begin': '(?!\\G)'
+        'end': '(?i)(?=</script>)'
+        'name': 'source.js.embedded.html'
         'patterns': [
           {
             'begin': '//'

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -124,26 +124,34 @@
     'include': '#embedded-code'
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i:style))\\b(?![^>]*/>)'
-    'captures':
+    'begin': '(?:^\\s+)?(<)((?i)style)(\\s+.*)?\\s*(>)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.html'
+      '2':
+        'name': 'entity.name.tag.style.html'
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
+        'name': 'punctuation.definition.tag.html'
+    'end': '(</)((?i)style)(>)'
+    'endCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'
       '2':
         'name': 'entity.name.tag.style.html'
       '3':
         'name': 'punctuation.definition.tag.html'
-    'end': '(</)((?i:style))(>)(?:\\s*\\n)?'
-    'name': 'source.css.embedded.html'
+    'name': 'meta.tag.style.html'
+    'contentName': 'source.css.embedded.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
-      }
-      {
-        'begin': '(>)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.tag.html'
-        'end': '(?=</(?i:style))'
+        'begin': '\\G'
+        'end': '(?=</(?i:style)>)'
         'patterns': [
           {
             'include': '#embedded-code'
@@ -156,29 +164,34 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i:script))\\b(?=[^>]*\\btype\\s*=\\s*[\'"]?text/(x-handlebars|(x-(handlebars-)?|ng-)?template|html)[\'"]?)(?![^>]*/>)'
+    'begin': '(?:^\\s+)?(<)((?i)script)(\\s+.*?\\btype\\s*=\\s*[\'"]?text/(?:x-handlebars|(?:x-(?:handlebars-)?|ng-)?template|html)[\'"]?.*?)(>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'
       '2':
         'name': 'entity.name.tag.script.html'
-    'end': '(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?'
-    'endCaptures':
-      '2':
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
         'name': 'punctuation.definition.tag.html'
+    'end': '(</)((?i)script)(>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.html'
+      '2':
+        'name': 'entity.name.tag.script.html'
+      '3':
+        'name': 'punctuation.definition.tag.html'
+    'name': 'meta.tag.script.html'
     'contentName': 'text.embedded.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
-      }
-      {
-        'begin': '(?<!</(?:script|SCRIPT))(>)'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.tag.html'
-          '2':
-            'name': 'entity.name.tag.script.html'
-        'end': '(</)((?i:script))'
+        'begin': '\\G'
+        'end': '(?=</(?i:script)>)'
         'patterns': [
           {
             'include': 'text.html.basic'
@@ -188,35 +201,49 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i:script))\\b(?=[^>]*\\btype\\s*=\\s*[\'"]?text/coffeescript[\'"]?)(?![^>]*/>)'
+    'begin': '(?:^\\s+)?(<)((?i)script)\\b(\\s+.*?\\btype\\s*=\\s*[\'"]?text/coffeescript[\'"]?.*?)(>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'
       '2':
         'name': 'entity.name.tag.script.html'
-    'end': '(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?'
-    'endCaptures':
-      '2':
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
         'name': 'punctuation.definition.tag.html'
+    'end': '(</)((?i)script)(>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.html'
+      '2':
+        'name': 'entity.name.tag.script.html'
+      '3':
+        'name': 'punctuation.definition.tag.html'
+    'name': 'meta.tag.script.html'
     'contentName': 'source.coffee.embedded.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
-      }
-      {
-        'begin': '(?<!</(?:script|SCRIPT))(>)'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.tag.html'
-          '2':
-            'name': 'entity.name.tag.script.html'
-        'end': '(</)((?i:script))'
+        'begin': '\\G'
+        'end': '(?=</(?i:script)>)'
         'patterns': [
           {
-            'captures':
-              '1':
+            'begin': '###'
+            'beginCaptures':
+              '0':
                 'name': 'punctuation.definition.comment.coffee'
-            'match': '(#).*?((?=</script)|$\\n?)'
+            'end': '###|(?=</script>)'
+            'name': 'comment.block.coffee'
+          }
+          {
+            'begin': '#'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.coffee'
+            'end': '(?=</script>|$)'
             'name': 'comment.line.number-sign.coffee'
           }
           {
@@ -227,43 +254,52 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?(<)((?i:script))\\b(?![^>]*/>)'
+    'begin': '(?:^\\s+)?(<)((?i)script)(\\s+.*?)?(>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.html'
       '2':
         'name': 'entity.name.tag.script.html'
-    'end': '(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?'
-    'endCaptures':
-      '2':
+      '3':
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      '4':
         'name': 'punctuation.definition.tag.html'
+    'end': '(</)((?i)script)(>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.html'
+      '2':
+        'name': 'entity.name.tag.script.html'
+      '3':
+        'name': 'punctuation.definition.tag.html'
+    'name': 'meta.tag.script.html'
     'contentName': 'source.js.embedded.html'
     'patterns': [
       {
-        'include': '#tag-stuff'
-      }
-      {
-        'begin': '(?<!</(?:script|SCRIPT))(>)'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.tag.html'
-          '2':
-            'name': 'entity.name.tag.script.html'
-        'end': '(</)((?i:script))'
+        'begin': '\\G'
+        'end': '(?=</(?i:script)>)'
         'patterns': [
           {
-            'captures':
-              '1':
+            'begin': '//'
+            'beginCaptures':
+              '0':
                 'name': 'punctuation.definition.comment.js'
-            'match': '(//).*?((?=</script)|$\\n?)'
+            'end': '(?=</script>|$)'
             'name': 'comment.line.double-slash.js'
           }
           {
             'begin': '/\\*'
-            'captures':
+            'beginCaptures':
               '0':
-                'name': 'punctuation.definition.comment.js'
+                'name': 'punctuation.definition.comment.begin.js'
             'end': '\\*/|(?=</script)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.begin.js'
             'name': 'comment.block.js'
           }
           {

--- a/spec/fixtures/syntax_test_html.html
+++ b/spec/fixtures/syntax_test_html.html
@@ -19,7 +19,6 @@
             }
         </style>
         <!-- ^ entity.name.tag.style.html -->
-        <style />
     </head>
     <body>
         <!-- Comment -->

--- a/spec/fixtures/syntax_test_html.html
+++ b/spec/fixtures/syntax_test_html.html
@@ -10,7 +10,6 @@
             <!-- <- source.js.embedded -->
             }
         //--></script>
-        <!-- ^ source.js.embedded.html -->
         <!--     ^ entity.name.tag.script.html -->
         <style type="text/css">
         <!--    ^ entity.other.attribute-name -->

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -50,9 +50,9 @@ describe 'HTML grammar', ->
         </script>
       '''
 
-      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
-      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'text.embedded.html']
-      expect(lines[1][1]).toEqual value: '<', scopes: ['text.html.basic', 'text.embedded.html', 'meta.tag.block.any.html', 'punctuation.definition.tag.begin.html']
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'meta.tag.script.html', 'text.embedded.html']
+      expect(lines[1][1]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'text.embedded.html', 'meta.tag.block.any.html', 'punctuation.definition.tag.begin.html']
 
   describe 'CoffeeScript script tags', ->
     it 'tokenizes the content inside the tag as CoffeeScript', ->
@@ -62,13 +62,33 @@ describe 'HTML grammar', ->
         </script>
       '''
 
-      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
-      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.coffee.embedded.html']
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html']
       # TODO: Remove when Atom 1.21 reaches stable
       if parseFloat(atom.getVersion()) <= 1.20
-        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'storage.type.function.coffee']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'storage.type.function.coffee']
       else
-        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
+        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
+
+    it 'recognizes closing script tags in comments', ->
+      lines = grammar.tokenizeLines '''
+        <script id='id' type='text/coffeescript'>
+          # comment </script>
+      '''
+
+      expect(lines[1][1]).toEqual value: '#', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'comment.line.number-sign.coffee', 'punctuation.definition.comment.coffee']
+      expect(lines[1][2]).toEqual value: ' comment ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'comment.line.number-sign.coffee']
+      expect(lines[1][3]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+
+      lines = grammar.tokenizeLines '''
+        <script id='id' type='text/coffeescript'>
+          ###
+          comment </script>
+      '''
+
+      expect(lines[1][1]).toEqual value: '###', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+      expect(lines[2][0]).toEqual value: '  comment ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'comment.block.coffee']
+      expect(lines[2][1]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
 
   describe 'JavaScript script tags', ->
     beforeEach ->
@@ -81,10 +101,30 @@ describe 'HTML grammar', ->
         </script>
       '''
 
-      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'punctuation.definition.tag.html']
+      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
 
-      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'source.js.embedded.html']
-      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'source.js.embedded.html', 'storage.type.var.js']
+      expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.js.embedded.html']
+      expect(lines[1][1]).toEqual value: 'var', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.js.embedded.html', 'storage.type.var.js']
+
+    it 'recognizes closing script tags in comments', ->
+      lines = grammar.tokenizeLines '''
+        <script id='id' type='text/javascript'>
+          // comment </script>
+      '''
+
+      expect(lines[1][1]).toEqual value: '//', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.js.embedded.html', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(lines[1][2]).toEqual value: ' comment ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.js.embedded.html', 'comment.line.double-slash.js']
+      expect(lines[1][3]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+
+      lines = grammar.tokenizeLines '''
+        <script id='id' type='text/javascript'>
+          /*
+          comment </script>
+      '''
+
+      expect(lines[1][1]).toEqual value: '/*', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.js.embedded.html', 'comment.block.js', 'punctuation.definition.comment.begin.js']
+      expect(lines[2][0]).toEqual value: '  comment ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.js.embedded.html', 'comment.block.js']
+      expect(lines[2][1]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
 
   describe "comments", ->
     it "tokenizes -- as an error", ->

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -42,6 +42,30 @@ describe 'HTML grammar', ->
       lines = grammar.tokenizeLines '<span><'
       expect(lines[0][3]).toEqual value: '<', scopes: ['text.html.basic']
 
+  describe 'script tags', ->
+    it 'tokenizes the tag attributes', ->
+      tokens = grammar.tokenizeLines '''
+        <script id="id" type="text/html">
+        </script>
+      '''
+
+      expect(tokens[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+      expect(tokens[0][1]).toEqual value: 'script', scopes: ['text.html.basic', 'meta.tag.script.html', 'entity.name.tag.script.html']
+      expect(tokens[0][3]).toEqual value: 'id', scopes: ['text.html.basic', 'meta.tag.script.html', 'meta.attribute-with-value.id.html', 'entity.other.attribute-name.id.html']
+      expect(tokens[0][4]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.script.html', 'meta.attribute-with-value.id.html', 'punctuation.separator.key-value.html']
+      expect(tokens[0][5]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.script.html', 'meta.attribute-with-value.id.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[0][6]).toEqual value: 'id', scopes: ['text.html.basic', 'meta.tag.script.html', 'meta.attribute-with-value.id.html', 'string.quoted.double.html', 'meta.toc-list.id.html']
+      expect(tokens[0][7]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.script.html', 'meta.attribute-with-value.id.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[0][9]).toEqual value: 'type', scopes: ['text.html.basic', 'meta.tag.script.html', 'entity.other.attribute-name.html']
+      expect(tokens[0][10]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.script.html']
+      expect(tokens[0][11]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.script.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[0][12]).toEqual value: 'text/html', scopes: ['text.html.basic', 'meta.tag.script.html', 'string.quoted.double.html']
+      expect(tokens[0][13]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.script.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[0][14]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+      expect(tokens[1][0]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+      expect(tokens[1][1]).toEqual value: 'script', scopes: ['text.html.basic', 'meta.tag.script.html', 'entity.name.tag.script.html']
+      expect(tokens[1][2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
+
   describe 'template script tags', ->
     it 'tokenizes the content inside the tag as HTML', ->
       lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

#90, take two, now that I understand what clamp patterns are.  Makes `style` and `script` tag matching a bit saner, and fixes some incorrect scopes.  In addition, overarching `meta.tag.<tag-type>.html` scopes have been added.

### Alternate Designs

~~Not sure yet.  Just wanted to get my PR fixed before investigating if this can be improved further now that I have two years more knowledge :).~~ - see 5c92fe4

### Benefits

Less wonky workarounds.

### Possible Drawbacks

~~Just a hunch, but I believe this somewhat hurts multiline tags.~~ - Fixed!

### Applicable Issues

Fixes #82
Fixes #120