### PR TITLE
Remove specs testing non-existent meta.outside-tag scopes

### DIFF
--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -15,30 +15,6 @@ describe 'HTML grammar', ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe 'text.html.basic'
 
-  describe 'meta.scope.outside-tag scope', ->
-    it 'tokenizes an empty file', ->
-      lines = grammar.tokenizeLines ''
-      expect(lines[0][0]).toEqual value: '', scopes: ['text.html.basic']
-
-    it 'tokenizes a single < as without freezing', ->
-      lines = grammar.tokenizeLines '<'
-      expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic']
-
-      lines = grammar.tokenizeLines ' <'
-      expect(lines[0][0]).toEqual value: ' <', scopes: ['text.html.basic']
-
-    it 'tokenizes <? without locking up', ->
-      lines = grammar.tokenizeLines '<?'
-      expect(lines[0][0]).toEqual value: '<?', scopes: ['text.html.basic']
-
-    it 'tokenizes >< as html without locking up', ->
-      lines = grammar.tokenizeLines '><'
-      expect(lines[0][0]).toEqual value: '><', scopes: ['text.html.basic']
-
-    it 'tokenizes < after tags without locking up', ->
-      lines = grammar.tokenizeLines '<span><'
-      expect(lines[0][3]).toEqual value: '<', scopes: ['text.html.basic']
-
   describe 'style tags', ->
     beforeEach ->
       waitsForPromise ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Removes `meta.outside-tag` scope specs, as that pattern was removed in #172.  The current patterns should have no chance of locking up.

### Alternate Designs

None.

### Benefits

Code maintenance.

### Possible Drawbacks

Future patterns that lock up in the scenarios tested.  However, I find that unlikely.

### Applicable Issues

atom/first-mate#100
atom/first-mate#101