### PR TITLE
Fix HTML snippets

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -1,4 +1,8 @@
-'.text.html:not(.embedded)':
+# Important: When adding a new snippet,
+# there is a second section halfway down this file
+# where you need to null-out the snippet to prevent it from
+# appearing in tags or embedded contexts
+'.text.html':
   # A
   'Anchor':
     'prefix': 'a'
@@ -386,7 +390,6 @@
     'prefix': 'wbr'
     'body': '<wbr>'
 
-
 # These null out the snippets so the snippets are not available when in a tag or
 # in embedded contexts like <script> and <style>
 '.text.html .meta.tag, .text.html .embedded':
@@ -466,6 +469,8 @@
   'Embed':
     'prefix': 'embed'
   # F
+  'Favicon':
+    'prefix': 'favicon'
   'Fieldset':
     'prefix': 'fieldset'
   'Figure Caption':
@@ -494,6 +499,8 @@
     'prefix': 'head'
   'Header':
     'prefix': 'header'
+  'Heading Group':
+    'prefix': 'hgroup'
   'Horizontal Rule':
     'prefix': 'hr'
   'HTML':
@@ -507,6 +514,8 @@
     'prefix': 'input'
   'Image':
     'prefix': 'img'
+  'Import':
+    'prefix': 'import'
   'Inserted Text':
     'prefix': 'ins'
   # J
@@ -531,6 +540,8 @@
     'prefix': 'map'
   'Mark':
     'prefix': 'mark'
+  'MathML':
+    'prefix': 'math'
   'Menu':
     'prefix': 'menu'
   'Menu Item':
@@ -554,7 +565,7 @@
   'Option Group':
     'prefix': 'optgroup'
   'Option':
-    'prefix': 'opt'
+    'prefix': 'option'
   'Output':
     'prefix': 'output'
   # P
@@ -570,10 +581,14 @@
   'Quote':
     'prefix': 'q'
   # R
+  'Ruby Base':
+    'prefix': 'rb'
   'Ruby Parenthesis':
     'prefix': 'rp'
   'Ruby Pronunciation':
     'prefix': 'rt'
+  'Ruby Text Container':
+    'prefix': 'rtc'
   'Ruby Annotation':
     'prefix': 'ruby'
   # S
@@ -605,6 +620,8 @@
     'prefix': 'summary'
   'Superscript':
     'prefix': 'sup'
+  'SVG':
+    'prefix': 'svg'
   # T
   'Table':
     'prefix': 'table'

--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -1,4 +1,4 @@
-'.text.html - .punctuation.tag.begin':
+'.text.html:not(.embedded)':
   # A
   'Anchor':
     'prefix': 'a'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -619,6 +619,7 @@ describe 'HTML grammar', ->
       # FIXME: This should just be atom.packages.loadPackage('snippets'),
       # but a bug in PackageManager::resolvePackagePath where it finds language-html's
       # `snippets` directory before the actual package necessitates passing an absolute path
+      # See https://github.com/atom/atom/issues/15953
       snippetsPath = path.join(atom.packages.resourcePath, 'node_modules', 'snippets')
       snippetsModule = require(atom.packages.loadPackage(snippetsPath).getMainModulePath())
 

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -611,3 +611,22 @@ describe 'HTML grammar', ->
     it "tolerates hyphens in other tag names", ->
       lines = grammar.tokenizeLines '<foo-bar>'
       expect(lines[0][1]).toEqual value: 'foo-bar', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+
+  describe "snippets", ->
+    snippetsModule = null
+
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('snippets').then (p) -> snippetsModule = p.mainModule
+
+      runs ->
+        # Do not load user snippets
+        spyOn(snippetsModule, 'loadUserSnippets').andCallFake (callback) -> callback({})
+
+      waitsFor 'snippets to load', (done) -> snippetsModule.onDidLoadSnippets(done)
+
+    it "suggests snippets", ->
+      expect(Object.keys(snippetsModule.parsedSnippetsForScopes(['.text.html'])).length).toBeGreaterThan 10
+
+    xit "does not suggest any HTML snippets when in embedded scripts", ->
+      expect(Object.keys(snippetsModule.parsedSnippetsForScopes(['.text.html .source.js.embedded.html'])).length).toBe 0


### PR DESCRIPTION
I was using TextMate's selector syntax instead of Atom's CSS syntax by accident.  I believe this restores pre-v0.48.0 snippet behavior.

Fixes atom/atom#15819