### PR TITLE
Include the Picture element to the snippets

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -262,6 +262,9 @@
   'Parameter':
     'prefix': 'param'
     'body': '<param name="$1" value="$2">$0'
+  'Picture':
+    'prefix': 'picture'
+    'body': '<picture>\n\t$1\n</picture>'
   'Preformatted Text':
     'prefix': 'pre'
     'body': '<pre>$1</pre>$0'
@@ -573,6 +576,8 @@
     'prefix': 'p'
   'Parameter':
     'prefix': 'param'
+  'Picture':
+    'prefix': 'picture'
   'Preformatted Text':
     'prefix': 'pre'
   'Progress':


### PR DESCRIPTION
### Description of the Change

Inclusion of the HTML Picture element as snippet.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture

### Alternate Designs

There where no alternate designs.
As this is a snippet build in the same way as the other HTML snippets in this repo.

### Benefits

This allows like similar element found in the snippets an easer writing of this element.

### Possible Drawbacks

None

### Applicable Issues

Missing HTML snippet in this repo.
