### PR TITLE
Allow for unrecognized tags to be self-closing

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -356,15 +356,16 @@
     ]
   }
   {
-    'begin': '(</?)([a-zA-Z0-9:-]+)'
+    # Opening tag (optionally self-closing)
+    'begin': '(<)([a-zA-Z0-9:-]+)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.html'
       '2':
         'name': 'entity.name.tag.other.html'
-    'end': '(>)'
+    'end': '/?>'
     'endCaptures':
-      '1':
+      '0':
         'name': 'punctuation.definition.tag.end.html'
     'name': 'meta.tag.other.html'
     'patterns': [
@@ -372,6 +373,20 @@
         'include': '#tag-stuff'
       }
     ]
+  }
+  {
+    # Closing tag, which doesn't allow attributes
+    'begin': '(</)([a-zA-Z0-9:-]+)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.begin.html'
+      '2':
+        'name': 'entity.name.tag.other.html'
+    'end': '>'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.tag.end.html'
+    'name': 'meta.tag.other.html'
   }
   {
     'include': '#text-entities'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -616,6 +616,32 @@ describe 'HTML grammar', ->
       expect(tokens[1]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
       expect(tokens[2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
 
+    it 'tokenizes unrecognized self-closing tags', ->
+      {tokens} = grammar.tokenizeLine '<foo/>'
+      expect(tokens[0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[2]).toEqual value: '/>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+
+    it 'tokenizes attributes in opening tags of unrecognized tag names', ->
+      {tokens} = grammar.tokenizeLine '<foo class="test">'
+      expect(tokens[0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[3]).toEqual value: 'class', scopes: ['text.html.basic', 'meta.tag.other.html', 'meta.attribute-with-value.class.html', 'entity.other.attribute-name.class.html']
+      expect(tokens[8]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+
+    it 'tokenizes the closing tag of an unrecognized tag name', ->
+      {tokens} = grammar.tokenizeLine '</foo>'
+      expect(tokens[0]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[2]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+
+    it 'does not tokenize attributes in closing tags of unrecognized tag names', ->
+      {tokens} = grammar.tokenizeLine '</foo class="test">'
+      expect(tokens[0]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.begin.html']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']
+      expect(tokens[2]).toEqual value: ' class="test"', scopes: ['text.html.basic', 'meta.tag.other.html']
+      expect(tokens[3]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.other.html', 'punctuation.definition.tag.end.html']
+
     it 'tolerates colons in other tag names', ->
       {tokens} = grammar.tokenizeLine '<foo:bar>'
       expect(tokens[1]).toEqual value: 'foo:bar', scopes: ['text.html.basic', 'meta.tag.other.html', 'entity.name.tag.other.html']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Recognize self-closing tags that aren't in the HTML spec.  Don't tokenize attributes in closing tags.

### Alternate Designs

None.

### Benefits

Self-closing tags will have the `/>` tokenized properly.

### Possible Drawbacks

None.

### Applicable Issues

None.