### PR TITLE
Adding lang and dir options to the HTML tag.

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -163,7 +163,7 @@
     'body': '<hr>'
   'HTML':
     'prefix': 'html'
-    'body': '<!DOCTYPE html>\n<html>\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$1</title>\n\t</head>\n\t<body>\n\t\t$2\n\t</body>\n</html>'
+    'body': '<!DOCTYPE html>\n<html lang="${1:en}" dir="${2:ltr}">\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$3</title>\n\t</head>\n\t<body>\n\t\t$4\n\t</body>\n</html>'
   # I
   'Italic':
     'prefix': 'i'


### PR DESCRIPTION
### Description of the Change

Almost (probably every single one) all projects I work on require having both the LANG and the DIR attributes to the HTML tag. That is because I usually work on projects that either support RTL or with multi-language support.
I thought it would be a neat little additions to have them shipped with the snippet that initializes the basic html document structure. I'm not sure if this requires testing or not? I basically just forked and made the change then pushed to a PR :)

### Alternate Designs

An alternative would be a separate snippet altogether. However I chose this because it's not a big enough change to require its own snippet.

### Benefits

Additional (but most of the time necessary) attributes to the HTML tag in the doc structure.

### Possible Drawbacks

Can't think of any.

### Applicable Issues

Working on multi-language apps/websites, or RTL/LTR support which ultimately has CSS that looks like this

```css
html[dir="ltr"] .main-menu {
  float: left;
}

html[dir="rtl"] .main-menu {
  float: right;
}
```

And for the lang tag, that helps l10n and l20n libraries decide what localization file to include based on the `lang=""` attribute.

---

r? please
Thanks!

Ahmed