### PR TITLE
Handle multiple ampersands followed by ASCII characters in attributes

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -415,7 +415,7 @@
   'attribute-entities':
     # https://www.w3.org/TR/html51/syntax.html#consume-a-character-reference
     # Because it would be infeasible to include the entire list of allowed entities,
-    # make sure that an equals sign or the end of a string does not follow a potential reference.
+    # make sure that a semicolon marks the end of a possible attribute reference.
     'patterns': [
       {
         'begin': '(&)(#\\d+|#[xX][0-9a-fA-F]+)'
@@ -431,7 +431,7 @@
         'name': 'constant.character.entity.html'
       }
       {
-        'begin': '(&)([a-zA-Z0-9]++)(?!["\'=])'
+        'begin': '(&)([a-zA-Z0-9]++)(?=;)'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.entity.begin.html'
@@ -444,8 +444,8 @@
         'name': 'constant.character.entity.html'
       }
       {
-        # In attributes, potential references that end with an equals sign are fine
-        'match': '&(?!\\s|<|&|[a-zA-Z0-9]+=)'
+        # In attributes, & followed by alphabetical characters are fine
+        'match': '&(?!\\s|<|&|[a-zA-Z0-9])'
         'name': 'invalid.illegal.bad-ampersand.html'
       }
     ]

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -423,6 +423,10 @@ describe 'HTML grammar', ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?one=1&type=json&topic=css">'
       expect(tokens[6]).toEqual value: 'http://example.com?one=1&type=json&topic=css', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
 
+    it 'does not tokenize multiple ampersands followed by alphabetical characters as entities', ->
+      {tokens} = grammar.tokenizeLine '<a href="http://example.com?price&something&yummy:&wow">'
+      expect(tokens[6]).toEqual value: 'http://example.com?price&something&yummy:&wow', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
+
     it 'tokenizes invalid ampersands', ->
       # Note: in order to replicate the following tests' behaviors, make sure you have language-hyperlink disabled
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&">'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When multiple ampersands were present in attributes without `=` separating them, language-html would incorrectly mark the whole thing starting from the first ampersand as a character entity.  To prevent that we now explicitly check for the existence of a semicolon before marking it as an entity.

### Alternate Designs

Hardcode the list of character entities to remove ambiguity.

### Benefits

No runaway highlighting.

### Possible Drawbacks

This still isn't the best because it's essentially the same as a regular `match`, meaning that autocomplete providers will still have to use string-based matching in attributes rather than token-based matching to autocomplete entities.

### Applicable Issues

#141