### PR TITLE
Remove begin/end matching for alphabetical character references

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -374,7 +374,7 @@
     ]
   }
   {
-    'include': '#text-entities'
+    'include': '#character-reference'
   }
   {
     'match': '<>'
@@ -391,31 +391,12 @@
         'include': '#python'
       }
     ]
-  'text-entities':
-    # https://www.w3.org/TR/html51/syntax.html#consume-a-character-reference
-    'patterns': [
-      {
-        'begin': '(&)([a-zA-Z0-9]+|#\\d+|#[xX][0-9a-fA-F]+)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.entity.begin.html'
-          '2':
-            'name': 'entity.name.entity.other.html'
-        'end': ';'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.entity.end.html'
-        'name': 'constant.character.entity.html'
-      }
-      {
-        'match': '&(?!\\s|<|&)'
-        'name': 'invalid.illegal.bad-ampersand.html'
-      }
-    ]
-  'attribute-entities':
-    # https://www.w3.org/TR/html51/syntax.html#consume-a-character-reference
-    # Because it would be infeasible to include the entire list of allowed entities,
-    # make sure that a semicolon marks the end of a possible attribute reference.
+  'character-reference':
+    # https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state
+    # We're not fully compliant with the spec (we don't catch missing semicolons or invalid references)
+    # but that is mostly to prevent tokenizing ambiguous ampersands as errors.
+    # That could be added in the future though if we add the list of all valid character references,
+    # as language-css does with property names.
     'patterns': [
       {
         'begin': '(&)(#\\d+|#[xX][0-9a-fA-F]+)'
@@ -431,20 +412,17 @@
         'name': 'constant.character.entity.html'
       }
       {
-        'begin': '(&)([a-zA-Z0-9]++)(?=;)'
-        'beginCaptures':
+        'match': '(&)([a-zA-Z0-9]+)(;)'
+        'name': 'constant.character.entity.html'
+        'captures':
           '1':
             'name': 'punctuation.definition.entity.begin.html'
           '2':
             'name': 'entity.name.entity.other.html'
-        'end': ';'
-        'endCaptures':
-          '0':
+          '3':
             'name': 'punctuation.definition.entity.end.html'
-        'name': 'constant.character.entity.html'
       }
       {
-        # In attributes, & followed by alphabetical characters are fine
         'match': '&(?!\\s|<|&|[a-zA-Z0-9])'
         'name': 'invalid.illegal.bad-ampersand.html'
       }
@@ -496,7 +474,7 @@
         'include': '#embedded-code'
       }
       {
-        'include': '#attribute-entities'
+        'include': '#character-reference'
       }
     ]
   'string-single-quoted':
@@ -514,7 +492,7 @@
         'include': '#embedded-code'
       }
       {
-        'include': '#attribute-entities'
+        'include': '#character-reference'
       }
     ]
   'tag-generic-attribute':
@@ -575,7 +553,7 @@
             'include': '#embedded-code'
           }
           {
-            'include': '#attribute-entities'
+            'include': '#character-reference'
           }
         ]
       }
@@ -595,7 +573,7 @@
             'include': '#embedded-code'
           }
           {
-            'include': '#attribute-entities'
+            'include': '#character-reference'
           }
         ]
       }
@@ -647,7 +625,7 @@
   'unquoted-attribute':
     'patterns': [
       {
-        'include': '#attribute-entities'
+        'include': '#character-reference'
       }
       {
         # https://www.w3.org/TR/html51/syntax.html#attribute-value-unquoted-state

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -364,21 +364,22 @@ describe 'HTML grammar', ->
       expect(tokens[8]).toEqual value: 'world', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-without-value.html', 'entity.other.attribute-name.html']
       expect(tokens[9]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
 
-  describe 'entities in text', ->
+  describe 'character references', ->
     it 'tokenizes & and characters after it', ->
+      # NOTE: &a should NOT be tokenized as a character reference as there is no semicolon following it
+      # We have no way of knowing if there will ever be a semicolon so we play conservatively.
       {tokens} = grammar.tokenizeLine '& &amp; &a'
 
       expect(tokens[0]).toEqual value: '& ', scopes: ['text.html.basic']
       expect(tokens[1]).toEqual value: '&', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.begin.html']
       expect(tokens[2]).toEqual value: 'amp', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
       expect(tokens[3]).toEqual value: ';', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.end.html']
-      expect(tokens[5]).toEqual value: '&', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.begin.html']
-      expect(tokens[6]).toEqual value: 'a', scopes: ['text.html.basic', 'constant.character.entity.html', 'entity.name.entity.other.html']
+      expect(tokens[4]).toEqual value: ' &a', scopes: ['text.html.basic']
 
       lines = grammar.tokenizeLines '&\n'
       expect(lines[0][0]).toEqual value: '&', scopes: ['text.html.basic']
 
-    it 'tokenizes hexadecimal and digit entities', ->
+    it 'tokenizes hexadecimal and digit character references', ->
       {tokens} = grammar.tokenizeLine '&#x00022; &#X00022; &#34;'
 
       expect(tokens[0]).toEqual value: '&', scopes: ['text.html.basic', 'constant.character.entity.html', 'punctuation.definition.entity.begin.html']
@@ -412,22 +413,21 @@ describe 'HTML grammar', ->
       {tokens} = grammar.tokenizeLine '&&'
       expect(tokens[0]).toEqual value: '&&', scopes: ['text.html.basic']
 
-  describe 'entities in attributes', ->
-    it 'tokenizes entities', ->
+    it 'tokenizes character references in attributes', ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&amp;">'
       expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.begin.html']
       expect(tokens[8]).toEqual value: 'amp', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'constant.character.entity.html', 'entity.name.entity.other.html']
       expect(tokens[9]).toEqual value: ';', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.end.html']
 
-    it 'does not tokenize query parameters as entities', ->
+    it 'does not tokenize query parameters as character references', ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?one=1&type=json&topic=css">'
       expect(tokens[6]).toEqual value: 'http://example.com?one=1&type=json&topic=css', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
 
-    it 'does not tokenize multiple ampersands followed by alphabetical characters as entities', ->
+    it 'does not tokenize multiple ampersands followed by alphabetical characters as character references', ->
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?price&something&yummy:&wow">'
       expect(tokens[6]).toEqual value: 'http://example.com?price&something&yummy:&wow', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html']
 
-    it 'tokenizes invalid ampersands', ->
+    it 'tokenizes invalid ampersands in attributes', ->
       # Note: in order to replicate the following tests' behaviors, make sure you have language-hyperlink disabled
       {tokens} = grammar.tokenizeLine '<a href="http://example.com?&">'
       expect(tokens[7]).toEqual value: '&', scopes: ['text.html.basic', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.double.html', 'invalid.illegal.bad-ampersand.html']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR flat-out removes the failed attempt to match character references using a begin/end match until a `;` was encountered, as we do not have enough context to stop matching when it is clear that the ampersand in question does not signify a character reference.

### Alternate Designs

Keep the begin/end match but investigate ways to prevent runaway tokenization, such as by adding the list of all valid character references.  I would like to implement that in the future but this PR is more meant to be a bugfix PR.

### Benefits

More conservative tokenization regarding ampersands to prevent runaway character reference tokenization.

### Possible Drawbacks

Setbacks to character reference autocompletion.
@DavidePastore @JonathanWolfe sorry to ping you two once again but I believe the only way character reference autocompletion will work is through manual text comparison, not by scopes.

### Applicable Issues

Fixes #181