### PR TITLE
Recognize hyphens as part of words for autocomplete, but not cursor movement

### DIFF
--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -1,6 +1,5 @@
 '.text.html':
   'editor':
-    'nonWordCharacters': '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?…'
     'commentStart': '<!-- '
     'commentEnd': ' -->'
     'foldEndPattern': '(?x)\n\t\t(</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl|section|article|header|footer|nav|aside)>\n\t\t|^(?!.*?<!--).*?--\\s*>\n\t\t|^<!--\\ end\\ tminclude\\ -->$\n\t\t|<\\?(?:php)?.*\\bend(if|for(each)?|while)\\b\n\t\t|\\{\\{?/(if|foreach|capture|literal|foreach|php|section|strip)\n\t\t|^[^{]*\\}\n\t\t|^\\s*\\)[,;]\n\t\t)'

--- a/settings/language-html.cson
+++ b/settings/language-html.cson
@@ -1,4 +1,6 @@
 '.text.html':
+  'autocomplete':
+    'extraWordCharacters': '-'
   'editor':
     'commentStart': '<!-- '
     'commentEnd': ' -->'


### PR DESCRIPTION
🍐 'd with @nathansobo 

Previously, we removed `-` to the `editor.nonWordCharacters` setting to allow words containing dashes to continue to be completed following https://github.com/atom/autocomplete-plus/pull/886. However, this changed cursor movement behavior. This PR reverts that change and *adds* `-` to `autocomplete.extraWordCharacters` to achieve the same effect. Depends on https://github.com/atom/autocomplete-plus/pull/944.