### PR TITLE
Adds <script type="application/graphql"> support

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -245,6 +245,55 @@
     ]
   }
   {
+    'begin': '(?i)(?=<script\\s+.*?\\btype\\s*=\\s*[\'"]?application/graphql[\'"]?(\\s+|>))'
+    'end': '(</)((?i)script)(>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.tag.html'
+      '2':
+        'name': 'entity.name.tag.script.html'
+      '3':
+        'name': 'punctuation.definition.tag.html'
+    'name': 'meta.tag.script.html'
+    'patterns': [
+      {
+        'begin': '(?i)\\G(<)(script)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.tag.html'
+          '2':
+            'name': 'entity.name.tag.script.html'
+        'end': '>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.tag.html'
+        'patterns': [
+          {
+            'include': '#tag-stuff'
+          }
+        ]
+      }
+      {
+        'begin': '(?!\\G)'
+        'end': '(?i)(?=</script>)'
+        'name': 'source.graphql.embedded.html'
+        'patterns': [
+          {
+            'begin': '#'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.graphql'
+            'end': '(?=(?i)</script>|$)'
+            'name': 'comment.line.number-sign.graphql'
+          }
+          {
+            'include': 'source.coffee'
+          }
+        ]
+      }
+    ]
+  }
+  {
     'begin': '(?i)(?=<script(\\s+|>))'
     'end': '(</)((?i)script)(>)'
     'endCaptures':


### PR DESCRIPTION
### Description of the Change
This PR adds support for 
```html
<script type="application/graphql">
query Query(id: 1) {
  id
  name
}
</script>
```

### Alternate Designs

Rely on JS highlighting

### Benefits

Users who wish to embed graphql in HTML (e.g. with polymer-apollo-client, or for documentation) will have code highlighting

### Possible Drawbacks

Code might not be sane - this is my first rodeo in atom grammar land.

### Applicable Issues

Please double check the code, if tests are needed please point me to relevant examples.
