### PR TITLE
Support multiline style attributes

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -538,66 +538,6 @@
     'name': 'meta.attribute-with-value.style.html'
     'patterns': [
       {
-        'match': '(")([^"]*)(")'
-        'name': 'string.quoted.double.html'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.string.begin.html'
-          '2':
-            'name': 'source.css.style.html'
-            'patterns': [
-              {
-                'match': '.+'
-                'name': 'meta.property-list.css'
-                'captures':
-                  '0':
-                    'patterns': [
-                      {
-                        'include': '#embedded-code'
-                      }
-                      {
-                        'include': '#entities'
-                      }
-                      {
-                        'include': 'source.css#rule-list-innards'
-                      }
-                    ]
-              }
-            ]
-          '3':
-            'name': 'punctuation.definition.string.end.html'
-      }
-      {
-        'match': "(')([^']*)(')"
-        'name': 'string.quoted.single.html'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.string.begin.html'
-          '2':
-            'name': 'source.css.style.html'
-            'patterns': [
-              {
-                'match': '.+'
-                'name': 'meta.property-list.css'
-                'captures':
-                  '0':
-                    'patterns': [
-                      {
-                        'include': '#embedded-code'
-                      }
-                      {
-                        'include': '#entities'
-                      }
-                      {
-                        'include': 'source.css#rule-list-innards'
-                      }
-                    ]
-              }
-            ]
-          '3':
-            'name': 'punctuation.definition.string.end.html'
-      }
-      {
         'begin': '"'
         'beginCaptures':
           '0':

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -610,20 +610,21 @@
         'contentName': 'source.css.style.html'
         'patterns': [
           {
-            'begin': '\\G'
-            'end': '(?=")'
+            'match': '[^"]+'
             'name': 'meta.property-list.css'
-            'patterns': [
-              {
-                'include': '#embedded-code'
-              }
-              {
-                'include': '#entities'
-              }
-              {
-                'include': 'source.css#rule-list-innards'
-              }
-            ]
+            'captures':
+              '0':
+                'patterns': [
+                  {
+                    'include': '#embedded-code'
+                  }
+                  {
+                    'include': '#entities'
+                  }
+                  {
+                    'include': 'source.css#rule-list-innards'
+                  }
+                ]
           }
         ]
       }
@@ -640,20 +641,21 @@
         'contentName': 'source.css.style.html'
         'patterns': [
           {
-            'begin': '\\G'
-            'end': "(?=')"
+            'match': "[^']+"
             'name': 'meta.property-list.css'
-            'patterns': [
-              {
-                'include': '#embedded-code'
-              }
-              {
-                'include': '#entities'
-              }
-              {
-                'include': 'source.css#rule-list-innards'
-              }
-            ]
+            'captures':
+              '0':
+                'patterns': [
+                  {
+                    'include': '#embedded-code'
+                  }
+                  {
+                    'include': '#entities'
+                  }
+                  {
+                    'include': 'source.css#rule-list-innards'
+                  }
+                ]
           }
         ]
       }

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -598,6 +598,68 @@
             'name': 'punctuation.definition.string.end.html'
       }
       {
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.html'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.html'
+        'name': 'string.quoted.double.html'
+        'contentName': 'source.css.style.html'
+        'patterns': [
+          {
+            'match': '[^"]+'
+            'name': 'meta.property-list.css'
+            'captures':
+              '0':
+                'patterns': [
+                  {
+                    'include': '#embedded-code'
+                  }
+                  {
+                    'include': '#entities'
+                  }
+                  {
+                    'include': 'source.css#rule-list-innards'
+                  }
+                ]
+          }
+        ]
+      }
+      {
+        'begin': "'"
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.html'
+        'end': "'"
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.html'
+        'name': 'string.quoted.single.html'
+        'contentName': 'source.css.style.html'
+        'patterns': [
+          {
+            'match': "[^']+"
+            'name': 'meta.property-list.css'
+            'captures':
+              '0':
+                'patterns': [
+                  {
+                    'include': '#embedded-code'
+                  }
+                  {
+                    'include': '#entities'
+                  }
+                  {
+                    'include': 'source.css#rule-list-innards'
+                  }
+                ]
+          }
+        ]
+      }
+      {
         'match': '([^\\s&>"\'<=`]|&(?=>))+'
         'name': 'string.unquoted.html'
         'captures':

--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -610,21 +610,20 @@
         'contentName': 'source.css.style.html'
         'patterns': [
           {
-            'match': '[^"]+'
+            'begin': '\\G'
+            'end': '(?=")'
             'name': 'meta.property-list.css'
-            'captures':
-              '0':
-                'patterns': [
-                  {
-                    'include': '#embedded-code'
-                  }
-                  {
-                    'include': '#entities'
-                  }
-                  {
-                    'include': 'source.css#rule-list-innards'
-                  }
-                ]
+            'patterns': [
+              {
+                'include': '#embedded-code'
+              }
+              {
+                'include': '#entities'
+              }
+              {
+                'include': 'source.css#rule-list-innards'
+              }
+            ]
           }
         ]
       }
@@ -641,21 +640,20 @@
         'contentName': 'source.css.style.html'
         'patterns': [
           {
-            'match': "[^']+"
+            'begin': '\\G'
+            'end': "(?=')"
             'name': 'meta.property-list.css'
-            'captures':
-              '0':
-                'patterns': [
-                  {
-                    'include': '#embedded-code'
-                  }
-                  {
-                    'include': '#entities'
-                  }
-                  {
-                    'include': 'source.css#rule-list-innards'
-                  }
-                ]
+            'patterns': [
+              {
+                'include': '#embedded-code'
+              }
+              {
+                'include': '#entities'
+              }
+              {
+                'include': 'source.css#rule-list-innards'
+              }
+            ]
           }
         ]
       }

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -398,6 +398,23 @@ describe 'HTML grammar', ->
           expect(tokens[17]).toEqual value: quote, scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'punctuation.definition.string.end.html']
           expect(tokens[18]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
 
+        it "tokenizes #{type}-quoted multiline attributes", ->
+          lines = grammar.tokenizeLines """
+            <span style=#{quote}display: none;
+            z-index: 10;#{quote}>
+          """
+
+          expect(lines[0][3]).toEqual value: 'style', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', 'entity.other.attribute-name.style.html']
+          expect(lines[0][5]).toEqual value: quote, scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'punctuation.definition.string.begin.html']
+          expect(lines[0][6]).toEqual value: 'display', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+          expect(lines[0][9]).toEqual value: 'none', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+          expect(lines[0][10]).toEqual value: ';', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+          expect(lines[1][0]).toEqual value: 'z-index', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+          expect(lines[1][3]).toEqual value: '10', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']
+          expect(lines[1][4]).toEqual value: ';', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+          expect(lines[1][5]).toEqual value: quote, scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'punctuation.definition.string.end.html']
+          expect(lines[1][6]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
+
       it 'tokenizes incomplete property lists', ->
         {tokens} = grammar.tokenizeLine '<span style="display: none">'
 

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -425,6 +425,21 @@ describe 'HTML grammar', ->
         expect(tokens[10]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
         expect(tokens[11]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
 
+        lines = grammar.tokenizeLines """
+          <span style=#{quote}display: none;
+          z-index: 10#{quote}>
+        """
+
+        expect(lines[0][3]).toEqual value: 'style', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', 'entity.other.attribute-name.style.html']
+        expect(lines[0][5]).toEqual value: quote, scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'punctuation.definition.string.begin.html']
+        expect(lines[0][6]).toEqual value: 'display', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+        expect(lines[0][9]).toEqual value: 'none', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+        expect(lines[0][10]).toEqual value: ';', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+        expect(lines[1][0]).toEqual value: 'z-index', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+        expect(lines[1][3]).toEqual value: '10', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'source.css.style.html', 'meta.property-list.css', 'meta.property-value.css', 'constant.numeric.css']
+        expect(lines[1][4]).toEqual value: quote, scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.style.html', "string.quoted.#{type}.html", 'punctuation.definition.string.end.html']
+        expect(lines[1][5]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
+
       it 'ends invalid quoted property lists correctly', ->
         {tokens} = grammar.tokenizeLine '<span style="s:">'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Supports style attributes that span multiple lines.

### Alternate Designs

None.

### Benefits

Multiline style attributes will end correctly and also be tokenized as CSS.

### Possible Drawbacks

I foresee none.

### Applicable Issues

Fixes #194