### PR TITLE
Recognize attributes with spaces around the equals sign

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -548,7 +548,7 @@
     # https://www.w3.org/TR/html51/syntax.html#attribute-name-state
     'patterns': [
       {
-        'begin': '([^\\s/=>"\'<]+)(=)'
+        'begin': '([^\\s/=>"\'<]+)\\s*(=)\\s*'
         'beginCaptures':
           '1':
             'name': 'entity.other.attribute-name.html'
@@ -577,7 +577,7 @@
       }
     ]
   'tag-style-attribute':
-    'begin': '\\b(style)(=)'
+    'begin': '\\b(style)\\s*(=)\\s*'
     'beginCaptures':
       '1':
         'name': 'entity.other.attribute-name.style.html'
@@ -670,7 +670,7 @@
       }
     ]
   'tag-id-attribute':
-    'begin': '\\b(id)(=)'
+    'begin': '\\b(id)\\s*(=)\\s*'
     'captures':
       '1':
         'name': 'entity.other.attribute-name.id.html'
@@ -724,7 +724,7 @@
       }
     ]
   'tag-class-attribute':
-    'begin': '\\b(class)(=)'
+    'begin': '\\b(class)\\s*(=)\\s*'
     'captures':
       '1':
         'name': 'entity.other.attribute-name.class.html'

--- a/spec/html-spec.coffee
+++ b/spec/html-spec.coffee
@@ -309,6 +309,38 @@ describe 'HTML grammar', ->
       expect(tokens[7]).toEqual value: "'", scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.single.html', 'punctuation.definition.string.end.html']
       expect(tokens[8]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
 
+    it 'recognizes a single attribute with spaces around the equals sign', ->
+      {tokens} = grammar.tokenizeLine '<span class   ="foo">'
+
+      expect(tokens[3]).toEqual value: 'class', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'entity.other.attribute-name.class.html']
+      expect(tokens[4]).toEqual value: '   ', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html']
+      expect(tokens[5]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'punctuation.separator.key-value.html']
+      expect(tokens[6]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[7]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html']
+      expect(tokens[8]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[9]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
+
+      {tokens} = grammar.tokenizeLine '<span class=   "foo">'
+
+      expect(tokens[3]).toEqual value: 'class', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'entity.other.attribute-name.class.html']
+      expect(tokens[4]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'punctuation.separator.key-value.html']
+      expect(tokens[5]).toEqual value: '   ', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html']
+      expect(tokens[6]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[7]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html']
+      expect(tokens[8]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[9]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
+
+      {tokens} = grammar.tokenizeLine '<span class   =   "foo">'
+
+      expect(tokens[3]).toEqual value: 'class', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'entity.other.attribute-name.class.html']
+      expect(tokens[4]).toEqual value: '   ', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html']
+      expect(tokens[5]).toEqual value: '=', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'punctuation.separator.key-value.html']
+      expect(tokens[6]).toEqual value: '   ', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html']
+      expect(tokens[7]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html']
+      expect(tokens[8]).toEqual value: 'foo', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html']
+      expect(tokens[9]).toEqual value: '"', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'meta.attribute-with-value.class.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html']
+      expect(tokens[10]).toEqual value: '>', scopes: ['text.html.basic', 'meta.tag.inline.span.html', 'punctuation.definition.tag.end.html']
+
     it 'recognizes a single attribute with an unquoted value', ->
       {tokens} = grammar.tokenizeLine '<span class=foo-3+5@>'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Spaces are allowed around the equals sign for attributes; recognize them.

### Alternate Designs

None.

### Benefits

There's not many visual benefits (excepting the case of `style`), but scopes will be more semantically correct.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #201