### PR TITLE
Add Tree-sitter grammar for HTML

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: "{build}"
 
+image: Visual Studio 2015
+
 platform: x64
 
 branches:

--- a/grammars/tree-sitter-html.cson
+++ b/grammars/tree-sitter-html.cson
@@ -1,0 +1,35 @@
+id: 'html'
+name: 'HTML'
+type: 'tree-sitter'
+parser: 'tree-sitter-html'
+legacyScopeName: 'text.html.basic'
+
+fileTypes: [
+  'html'
+]
+
+folds: [
+  {
+    type: ['start_tag', 'raw_start_tag', 'self_closing_tag'],
+    start: {index: 1},
+    end: {index: -1}
+  }
+  {
+    type: ['element', 'raw_element'],
+    start: {index: 0},
+    end: {index: -1}
+  }
+]
+
+comments:
+  start: '<!--'
+  end: '-->'
+
+scopes:
+  'tag_name': 'entity.name.tag'
+  'raw_tag_name': 'entity.name.tag'
+  'erroneous_end_tag_name': 'invalid.illegal'
+  'doctype': 'meta.tag.doctype.html'
+  'attribute_name': 'entity.other.attribute-name'
+  'attribute_value': 'string.html'
+  'comment': 'comment.block.html'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.3",
-    "tree-sitter-html": "^0.1.0"
+    "tree-sitter-html": "^0.1.2"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/atom/language-html/issues"
   },
   "dependencies": {
-    "atom-grammar-test": "^0.6.3"
+    "atom-grammar-test": "^0.6.3",
+    "tree-sitter-html": "^0.1.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
This PR adds support for parsing HTML files with Tree-sitter.

Refs https://github.com/atom/atom/pull/16299
Closes https://github.com/atom/language-html/issues/28

🍐'd with @queerviolet 