### PR TITLE
Make use of Tree-sitter grammar injection

### DIFF
--- a/grammars/tree-sitter-ejs.cson
+++ b/grammars/tree-sitter-ejs.cson
@@ -1,0 +1,33 @@
+id: 'ejs'
+name: 'EJS'
+type: 'tree-sitter'
+parser: 'tree-sitter-embedded-template'
+
+fileTypes: [
+  'ejs'
+]
+
+injectionRegExp: '^(ejs|EJS)$'
+
+folds: [
+  {
+    type: ['directive', 'output_directive'],
+    start: {index: 0},
+    end: {index: -1}
+  }
+]
+
+comments:
+  start: '<!--'
+  end: '-->'
+
+scopes:
+  'comment': 'comment.block'
+
+  '"<%"': 'keyword.control.directive'
+  '"<%="': 'keyword.control.directive'
+  '"<%_"': 'keyword.control.directive'
+  '"<%-"': 'keyword.control.directive'
+  '"%>"': 'keyword.control.directive'
+  '"-%>"': 'keyword.control.directive'
+  '"_%>"': 'keyword.control.directive'

--- a/grammars/tree-sitter-html.cson
+++ b/grammars/tree-sitter-html.cson
@@ -8,6 +8,8 @@ fileTypes: [
   'html'
 ]
 
+injectionRegExp: '(HTML|html|Html)$'
+
 folds: [
   {
     type: ['start_tag', 'raw_start_tag', 'self_closing_tag'],
@@ -26,6 +28,7 @@ comments:
   end: '-->'
 
 scopes:
+  'fragment': 'source.html'
   'tag_name': 'entity.name.tag'
   'raw_tag_name': 'entity.name.tag'
   'erroneous_end_tag_name': 'invalid.illegal'

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,18 @@
+exports.activate = function() {
+  atom.grammars.addInjectionPoint('html', {
+    type: 'raw_element',
+
+    language (node) {
+      const openTag = node.firstChild;
+      if (openTag.child(1).text === 'script') {
+        return 'javascript'
+      } else {
+        return 'css'
+      }
+    },
+
+    content (node) {
+      return node.child(1)
+    }
+  })
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,6 @@
 exports.activate = function() {
+  if (!atom.grammars.addInjectionPoint) return
+
   atom.grammars.addInjectionPoint('html', {
     type: 'raw_element',
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,4 +15,24 @@ exports.activate = function() {
       return node.child(1)
     }
   })
+
+  atom.grammars.addInjectionPoint('ejs', {
+    type: 'template',
+
+    language (node) { return 'javascript' },
+
+    content (node) {
+      return node.descendantsOfType('code')
+    }
+  })
+
+  atom.grammars.addInjectionPoint('ejs', {
+    type: 'template',
+
+    language (node) { return 'html' },
+
+    content (node) {
+      return node.descendantsOfType('content')
+    }
+  })
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.3",
-    "tree-sitter-html": "^0.12.0"
+    "tree-sitter-html": "^0.12.0",
+    "tree-sitter-embedded-template": "^0.12.1"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.3",
-    "tree-sitter-html": "^0.12.0",
+    "tree-sitter-html": "^0.12.1",
     "tree-sitter-embedded-template": "^0.12.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "language-html",
+  "main": "lib/main",
   "version": "0.50.1",
   "description": "HTML language support in Atom",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-html",
   "main": "lib/main",
-  "version": "0.50.1",
+  "version": "0.50.2-0",
   "description": "HTML language support in Atom",
   "engines": {
     "atom": "*",


### PR DESCRIPTION
This PR uses Atom's [new system](https://github.com/atom/atom/pull/17551) for handling injected languages with Tree-sitter. It adds syntax highlighting for:

* JavaScript inside of `script` tags in HTML files
* HTML inside of certain template strings in JavaScript files
* EJS templates