### PR TITLE
Remove charset='utf-8' from scriptsrc

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -303,7 +303,7 @@
     'body': '<script${1: type="${2:text/javascript}"}>\n\t$3\n</script>'
   'Script With External Source':
     'prefix': 'scriptsrc'
-    'body': '<script src="$1" charset="${2:utf-8}"></script>$0'
+    'body': '<script src="$1"></script>$0'
   'Section':
     'prefix': 'section'
     'body': '<section>\n\t$1\n</section>'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Remove the charset attribute from the "**Script With External Source**". According to W3C, the charset attribute on the script element is obsolete.
![W3C Warning](https://user-images.githubusercontent.com/20735862/44624698-d43be280-a912-11e8-99a0-ba69b150e677.png)


### Alternate Designs

None 

### Benefits

Removes obsolete code and minifies HTML. 

### Possible Drawbacks

None

### Applicable Issues

None
