### PR TITLE
Add meta tag for viewport to body snippet

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -163,7 +163,7 @@
     'body': '<hr>'
   'HTML':
     'prefix': 'html'
-    'body': '<!DOCTYPE html>\n<html lang="${1:en}" dir="${2:ltr}">\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$3</title>\n\t</head>\n\t<body>\n\t\t$4\n\t</body>\n</html>'
+    'body': '<!DOCTYPE html>\n<html lang="${1:en}" dir="${2:ltr}">\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<meta name="viewport" content="width=device-width, initial-scale=1.0">\n\t\t<title>$3</title>\n\t</head>\n\t<body>\n\t\t$4\n\t</body>\n</html>'
   # I
   'Italic':
     'prefix': 'i'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Almost all the new websites being written today are responsive, and thereby require the viewport meta tag. It affects the way a web browser on a mobile device renders any website.

To make a website easy to use on a mobile device, generally, it is necessary to make it responsive.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
None that I could think of.

### Benefits

<!-- What benefits will be realized by the code change? -->
Almost all the new websites being written today are responsive, and thereby require the viewport meta tag. Adding the same to the snippet for body strikes off one item from numerous things a front-end web dev has to keep in mind.

Also any web developer would expect this tag to be present in a snippet for html body.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
I cannot see any drawbacks of adding the viewport meta tag to the snippet.

### Applicable Issues

Fixes #199 
