### PR TITLE
remove ejs from html scope filetypes

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -1,6 +1,5 @@
 'scopeName': 'text.html.basic'
 'fileTypes': [
-  'ejs'
   'htm'
   'html'
   'kit'


### PR DESCRIPTION
EJS is listed under the html scope filetypes and therefore is treated as html. It should be done similar to ERB in this package where there is a html.erb and it is not treated as literal html.

### Description of the Change

Remove EJS from html scope file types.

### Benefits

EJS no longer treated as literal html and is instead treated correctly like ERB is.

### Possible Drawbacks

None.

### Applicable Issues

https://stackoverflow.com/questions/52987984/how-do-i-stop-csslint-and-jshint-from-linting-my-ejs-in-atom
