### PR TITLE
Use GraphQL grammar to highlight its script block

### DIFF
--- a/grammars/html.cson
+++ b/grammars/html.cson
@@ -287,7 +287,7 @@
             'name': 'comment.line.number-sign.graphql'
           }
           {
-            'include': 'source.coffee'
+            'include': 'source.graphql'
           }
         ]
       }


### PR DESCRIPTION
### Description of the Change

As discovered in https://github.com/atom/language-javascript/pull/604#issuecomment-443532149, the script block for GraphQL in HTML grammar uses CoffeeScript as its grammar. While it has been seemingly working 'fine' for the time being, we should encourage using the appropriate [GraphQL grammar](https://atom.io/packages/language-graphql) for more accurate highlighting instead.

Various grammars in Atom already make use of the community package (JavaScript, Ruby, GFM), with currently this one being the odd-one-out.

### Alternate Designs

None considered.

### Benefits

More accurate highlighting for GraphQL in script tags in both Atom and GitHub.

### Possible Drawbacks

We lose out-of-the-box 'support' for GraphQL in this case. This should be noted in release notes that users will need to install the appropriate [language-graphql community package](https://atom.io/packages/language-graphql) instead.

### Applicable Issues

https://github.com/atom/language-javascript/pull/604

cc @FluorescentHallucinogen @50Wliu 