### PR TITLE
Improve comment handling in EJS and ERB

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -21,7 +21,8 @@ exports.activate = function () {
   atom.grammars.addInjectionPoint('text.html.ejs', {
     type: 'template',
     language (node) { return 'javascript' },
-    content (node) { return node.descendantsOfType('code') }
+    content (node) { return node.descendantsOfType('code') },
+    newlinesBetween: true
   })
 
   atom.grammars.addInjectionPoint('text.html.ejs', {

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,7 +34,8 @@ exports.activate = function () {
   atom.grammars.addInjectionPoint('text.html.erb', {
     type: 'template',
     language (node) { return 'ruby' },
-    content (node) { return node.descendantsOfType('code') }
+    content (node) { return node.descendantsOfType('code') },
+    newlinesBetween: true
   })
 
   atom.grammars.addInjectionPoint('text.html.erb', {


### PR DESCRIPTION
Depends on https://github.com/atom/atom/pull/19279

---

https://github.com/atom/language-ruby/issues/263 identifies a bug where Ruby line comments can break ERB syntax highlighting. A similar bug exists for JavaScript comments in EJS.

Fixing this bug involves two things:

1. https://github.com/atom/atom/pull/19279: An enhancement to the `addInjectionPoint` API in atom/atom
2. This pull request: An update in language-html to make use of this enhanced API for handling ERB and and EJS in HTML

For full details, please see https://github.com/atom/atom/pull/19279.
