### PR TITLE
Add meta tag with viewport.

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -163,7 +163,7 @@
     'body': '<hr>'
   'HTML':
     'prefix': 'html'
-    'body': '<!DOCTYPE html>\n<html lang="${1:en}" dir="${2:ltr}">\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<title>$3</title>\n\t</head>\n\t<body>\n\t\t$4\n\t</body>\n</html>'
+    'body': '<!DOCTYPE html>\n<html lang="${1:en}" dir="${2:ltr}">\n\t<head>\n\t\t<meta charset="utf-8">\n\t\t<meta name="viewport" content="width=device-width, initial-scale=1">\n\t<title>$3</title>\n\t</head>\n\t<body>\n\t\t$4\n\t</body>\n</html>'
   # I
   'Italic':
     'prefix': 'i'


### PR DESCRIPTION
Insertion of meta tag viewport to html snippet.

### Description of the Change

- Just added a meta tag with viewport inside head tag to prevent that users insert it manually.

### Alternate Designs

- Not aplicable.

### Benefits

- Practicality when inserting a responsive template with meta tag viewport.

### Possible Drawbacks
- None

### Applicable Issues
- None
 
