### PR TITLE
 Add scopes for punctuation.

### DIFF
--- a/grammars/tree-sitter-html.cson
+++ b/grammars/tree-sitter-html.cson
@@ -34,3 +34,19 @@ scopes:
   'attribute_name': 'entity.other.attribute-name'
   'attribute_value': 'string.html'
   'comment': 'comment.block.html'
+
+  '
+    start_tag > "<",
+    end_tag > "</"
+  ': 'punctuation.definition.tag.begin'
+  '
+    start_tag > ">",
+    end_tag > ">"
+  ': 'punctuation.definition.tag.end'
+
+  'attribute > "="': 'punctuation.separator.key-value.html'
+
+  # quoted_attribute_value has three child nodes: ", attribute_value, and ".
+  # Target the first and last.
+  "quoted_attribute_value > '\"':nth-child(0)": 'punctuation.definition.string.begin'
+  "quoted_attribute_value > '\"':nth-child(2)": 'punctuation.definition.string.end'

--- a/grammars/tree-sitter-html.cson
+++ b/grammars/tree-sitter-html.cson
@@ -48,5 +48,9 @@ scopes:
 
   # quoted_attribute_value has three child nodes: ", attribute_value, and ".
   # Target the first and last.
+  # Single quotes and double quotes are targeted in separate selectors because
+  # of quote-escaping difficulties.
   "quoted_attribute_value > '\"':nth-child(0)": 'punctuation.definition.string.begin'
+  'quoted_attribute_value > "\'":nth-child(0)': 'punctuation.definition.string.begin'
   "quoted_attribute_value > '\"':nth-child(2)": 'punctuation.definition.string.end'
+  'quoted_attribute_value > "\'":nth-child(2)': 'punctuation.definition.string.end'

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.3",
-    "tree-sitter-html": "^0.15.0",
-    "tree-sitter-embedded-template": "^0.15.0"
+    "tree-sitter-embedded-template": "^0.15.0",
+    "tree-sitter-html": "^0.15.0"
   },
   "devDependencies": {
-    "coffeelint": "^1.10.1"
+    "coffeelint": "^1.10.1",
+    "dedent": "^0.7.0"
   }
 }

--- a/spec/tree-sitter-spec.js
+++ b/spec/tree-sitter-spec.js
@@ -1,0 +1,81 @@
+const dedent = require('dedent')
+
+describe('Tree-sitter HTML grammar', () => {
+
+  beforeEach(async () => {
+    atom.config.set('core.useTreeSitterParsers', true)
+    await atom.packages.activatePackage('language-html')
+  })
+
+  it('tokenizes punctuation in HTML tags and attributes', async () => {
+    const editor = await atom.workspace.open(`test.html`)
+
+    editor.setText(dedent`
+      <html lang="en">
+        <head>
+          <meta charset='utf-8'>
+          <meta name='"' content="This'll test single and double quotes.">
+        </head>
+        <body>
+      </html>
+    `)
+
+    // Tag punctuation.
+    expect(editor.scopeDescriptorForBufferPosition([0, 0]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.tag.begin'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([0, 15]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.tag.end'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([6, 0]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.tag.begin'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([6, 6]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.tag.end'
+    )
+
+    // Attribute-value pair punctuation.
+    expect(editor.scopeDescriptorForBufferPosition([0, 10]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.separator.key-value.html'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([2, 18]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.string.begin'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([2, 24]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.string.end'
+    )
+
+    // Ensure an attribute value delimited by single-quotes won't mark a
+    // double-quote in the value as punctuation.
+    expect(editor.scopeDescriptorForBufferPosition([3, 15]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.string.begin'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([3, 16]).toString()).toBe(
+      '.text.html.basic .source.html .string.html'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([3, 17]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.string.end'
+    )
+
+    // Ensure an attribute value delimited by double-quotes won't mark a
+    // single-quote in the value as punctuation.
+    expect(editor.scopeDescriptorForBufferPosition([3, 27]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.string.begin'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([3, 32]).toString()).toBe(
+      '.text.html.basic .source.html .string.html'
+    )
+
+    expect(editor.scopeDescriptorForBufferPosition([3, 66]).toString()).toBe(
+      '.text.html.basic .source.html .punctuation.definition.string.end'
+    )
+  })
+})


### PR DESCRIPTION
### Description of the Change

Adds appropriate `punctuation` scopes to the following characters:

* angle-brackets around HTML tags, as distinct from the tag name itself (e.g., `<p>`)
* attribute value delimiters (single and double quotes)
* the `=` between an attribute’s name and value

### Alternate Designs

None that I can see. This is how tree-sitter grammars are meant to work.

I intentionally left off the `.html` at the ends of each scope name. This shouldn’t be necessary in order to target HTML-specific punctuation in a syntax theme, even when dealing with HTML injected into another source file.

### Benefits

The `tree-sitter-html` grammar was not adding `punctuation` scopes to HTML documents. This means that it was impossible (or highly impractical) to style these punctuation marks in any way that distinguished them from ordinary, unscoped text. See #224.

### Possible Drawbacks

Opening Pandora’s box, perhaps? But this is just about inching the tree-sitter grammar toward feature parity with its TM-style sibling.

### Applicable Issues

Fixes #224.