### PR TITLE
Add class field to span snippet

### DIFF
--- a/snippets/language-html.cson
+++ b/snippets/language-html.cson
@@ -318,7 +318,7 @@
     'body': '<source src="${1:https://}" type="${2:video/}">$0'
   'Span':
     'prefix': 'span'
-    'body': '<span>$1</span>$0'
+    'body': '<span class="$1">$2</span>$0'
   'Strong':
     'prefix': 'strong'
     'body': '<strong>$1</strong>$0'


### PR DESCRIPTION
Changes the `span` snippet to include the class attribute.
You rarely use `span`s without a class anyway, this also matches the behavior of the current `div` snippet.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add `class=""` to the snippets for `span`

### Alternate Designs

leave it unchanged

### Benefits

Less typing, The primary reason to use a `span` anyway is to add a custom class. Matches the snippet for `div`, leading to better coherency.

### Possible Drawbacks

This changes existing snippet behavior, some might experience trouble adapting

### Applicable Issues

None?