### PR TITLE
Implement naming conventions in HTML grammar

### DIFF
--- a/grammars/tree-sitter-ejs.cson
+++ b/grammars/tree-sitter-ejs.cson
@@ -23,14 +23,17 @@ comments:
   end: '%>'
 
 scopes:
-  'comment_directive': 'comment.block'
-  'comment_directive > "%>"': 'comment.block'
+  'template': 'source.ejs'
 
-  '"<%#"': 'keyword.control.directive'
-  '"<%"': 'keyword.control.directive'
-  '"<%="': 'keyword.control.directive'
-  '"<%_"': 'keyword.control.directive'
-  '"<%-"': 'keyword.control.directive'
-  '"%>"': 'keyword.control.directive'
-  '"-%>"': 'keyword.control.directive'
-  '"_%>"': 'keyword.control.directive'
+  'comment_directive': 'comment.block.html.ejs'
+
+  '"<%#"': 'punctuation.definition.comment.html.ejs'
+  'comment_directive > "%>"': 'punctuation.definition.comment.html.ejs'
+
+  '"<%"': 'punctuation.delimiter.embedded.html.ejs'
+  '"<%="': 'punctuation.delimiter.embedded.html.ejs'
+  '"<%_"': 'punctuation.delimiter.embedded.html.ejs'
+  '"<%-"': 'punctuation.delimiter.embedded.html.ejs'
+  '"%>"': 'punctuation.delimiter.embedded.html.ejs'
+  '"-%>"': 'punctuation.delimiter.embedded.html.ejs'
+  '"_%>"': 'punctuation.delimiter.embedded.html.ejs'

--- a/grammars/tree-sitter-erb.cson
+++ b/grammars/tree-sitter-erb.cson
@@ -23,14 +23,17 @@ comments:
   end: '%>'
 
 scopes:
-  'comment_directive': 'comment.block'
-  'comment_directive > "%>"': 'comment.block'
+  'template': 'source.erb'
 
-  '"<%#"': 'keyword.control.directive'
-  '"<%"': 'keyword.control.directive'
-  '"<%="': 'keyword.control.directive'
-  '"<%_"': 'keyword.control.directive'
-  '"<%-"': 'keyword.control.directive'
-  '"%>"': 'keyword.control.directive'
-  '"-%>"': 'keyword.control.directive'
-  '"_%>"': 'keyword.control.directive'
+  'comment_directive': 'comment.block.html.erb'
+
+  '"<%#"': 'punctuation.definition.comment.html.erb'
+  'comment_directive > "%>"': 'punctuation.definition.comment.html.erb'
+
+  '"<%"': 'punctuation.delimiter.embedded.html.erb'
+  '"<%="': 'punctuation.delimiter.embedded.html.erb'
+  '"<%_"': 'punctuation.delimiter.embedded.html.erb'
+  '"<%-"': 'punctuation.delimiter.embedded.html.erb'
+  '"%>"': 'punctuation.delimiter.embedded.html.erb'
+  '"-%>"': 'punctuation.delimiter.embedded.html.erb'
+  '"_%>"': 'punctuation.delimiter.embedded.html.erb'

--- a/grammars/tree-sitter-html.cson
+++ b/grammars/tree-sitter-html.cson
@@ -28,29 +28,41 @@ comments:
 
 scopes:
   'fragment': 'source.html'
-  'tag_name': 'entity.name.tag'
-  'erroneous_end_tag_name': 'invalid.illegal'
-  'doctype': 'meta.tag.doctype.html'
-  'attribute_name': 'entity.other.attribute-name'
-  'attribute_value': 'string.html'
+
+  # Entity
+  'tag_name': 'entity.tag.html'
+  'erroneous_end_tag_name': 'entity.tag.html.invalid.illegal'
+  'attribute_name': 'entity.attribute.html'
+
+  # String
+  'attribute > attribute_value': 'string.unquoted.attribute-value.html'
+  'attribute > quoted_attribute_value': 'string.quoted.attribute-value.html'
+
+  # Text
+  'text': 'text.html'
+
+  # Comment
   'comment': 'comment.block.html'
 
-  '
-    start_tag > "<",
-    end_tag > "</"
-  ': 'punctuation.definition.tag.begin'
-  '
-    start_tag > ">",
-    end_tag > ">"
-  ': 'punctuation.definition.tag.end'
+  # Punctuation
+  '"<"': 'punctuation.definition.tag.html'
+  '"</"': 'punctuation.definition.tag.html'
+  '">"': 'punctuation.definition.tag.html'
+  '"/>"': 'punctuation.definition.tag.html'
+  '"<!"': 'punctuation.definition.tag.doctype.html'
+  'doctype > ">"': 'punctuation.definition.tag.doctype.html'
+  '"\\""': 'punctuation.definition.string.html'
+  '"\'"': 'punctuation.definition.string.html'
+  '"="': 'punctuation.association.pair.attribute-value.html'
 
-  'attribute > "="': 'punctuation.separator.key-value.html'
+  'ERROR > "<"': 'punctuation.definition.tag.html.invalid.illegal'
+  'ERROR > "</"': 'punctuation.definition.tag.html.invalid.illegal'
+  'ERROR > ">"': 'punctuation.definition.tag.html.invalid.illegal'
+  'ERROR > "/>"': 'punctuation.definition.tag.html.invalid.illegal'
+  'ERROR > "<!"': 'punctuation.definition.tag.doctype.html.invalid.illegal'
+  'ERROR > "\\""': 'punctuation.definition.string.html.invalid.illegal'
+  'ERROR > "\'"': 'punctuation.definition.string.html.invalid.illegal'
+  'ERROR > "="': 'punctuation.association.pair.html.invalid.illegal'
 
-  # quoted_attribute_value has three child nodes: ", attribute_value, and ".
-  # Target the first and last.
-  # Single quotes and double quotes are targeted in separate selectors because
-  # of quote-escaping difficulties.
-  "quoted_attribute_value > '\"':nth-child(0)": 'punctuation.definition.string.begin'
-  'quoted_attribute_value > "\'":nth-child(0)': 'punctuation.definition.string.begin'
-  "quoted_attribute_value > '\"':nth-child(2)": 'punctuation.definition.string.end'
-  'quoted_attribute_value > "\'":nth-child(2)': 'punctuation.definition.string.end'
+  # Meta
+  'doctype': 'meta.doctype.html'

--- a/spec/tree-sitter-spec.js
+++ b/spec/tree-sitter-spec.js
@@ -22,60 +22,60 @@ describe('Tree-sitter HTML grammar', () => {
 
     // Tag punctuation.
     expect(editor.scopeDescriptorForBufferPosition([0, 0]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.tag.begin'
+      '.text.html.basic .source.html .punctuation.definition.tag.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([0, 15]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.tag.end'
+      '.text.html.basic .source.html .punctuation.definition.tag.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([6, 0]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.tag.begin'
+      '.text.html.basic .source.html .punctuation.definition.tag.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([6, 6]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.tag.end'
+      '.text.html.basic .source.html .punctuation.definition.tag.html'
     )
 
     // Attribute-value pair punctuation.
     expect(editor.scopeDescriptorForBufferPosition([0, 10]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.separator.key-value.html'
+      '.text.html.basic .source.html .punctuation.association.pair.attribute-value.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([2, 18]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.string.begin'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html .punctuation.definition.string.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([2, 24]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.string.end'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html .punctuation.definition.string.html'
     )
 
     // Ensure an attribute value delimited by single-quotes won't mark a
     // double-quote in the value as punctuation.
     expect(editor.scopeDescriptorForBufferPosition([3, 15]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.string.begin'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html .punctuation.definition.string.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([3, 16]).toString()).toBe(
-      '.text.html.basic .source.html .string.html'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([3, 17]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.string.end'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html .punctuation.definition.string.html'
     )
 
     // Ensure an attribute value delimited by double-quotes won't mark a
     // single-quote in the value as punctuation.
     expect(editor.scopeDescriptorForBufferPosition([3, 27]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.string.begin'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html .punctuation.definition.string.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([3, 32]).toString()).toBe(
-      '.text.html.basic .source.html .string.html'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html'
     )
 
     expect(editor.scopeDescriptorForBufferPosition([3, 66]).toString()).toBe(
-      '.text.html.basic .source.html .punctuation.definition.string.end'
+      '.text.html.basic .source.html .string.quoted.attribute-value.html .punctuation.definition.string.html'
     )
   })
 })


### PR DESCRIPTION
### Description of the Change

This is a rewrite of the Tree-sitter grammar to implement [naming conventions](https://github.com/atom/flight-manual.atom.io/pull/564) for syntax scopes.

### Benefits

- Improvements on punctuation.
- Highlighting to be consistent with other languages.

### Possible Drawbacks

Some new scopes to be added to themes. The changes aim to facilitate theme development, filling the [template](https://github.com/atom/apm/pull/883) is enough to ensure coherent highlighting across languages, instead of painfully creating styling rules for every language separately.

### Applicable Issues

- https://github.com/atom/atom/issues/8430

### Related Pull Requests

- [Naming conventions documentation](https://github.com/atom/flight-manual.atom.io/pull/564)
- [Implementation in template theme](https://github.com/atom/apm/pull/883)
- [Implementation in default syntax themes](https://github.com/atom/atom/pull/20524)
- [Implementation in C and C++ grammars](https://github.com/atom/language-c/pull/351)
- [Implementation in CSS grammar](https://github.com/atom/language-css/pull/167)
- [Implementation in Go grammar](https://github.com/atom/language-go/pull/182)
- [Implementation in JavaScript and Regex grammars](https://github.com/atom/language-javascript/pull/690)
- [Implementation in Python grammar](https://github.com/atom/language-python/pull/313)
- [Implementation in Ruby grammar](https://github.com/atom/language-ruby/pull/291)