### PR TITLE
Install the exact version instead of range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,265 @@
 {
   "name": "language-html",
   "version": "0.53.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.53.1",
+      "license": "MIT",
+      "dependencies": {
+        "atom-grammar-test": "^0.6.3",
+        "tree-sitter-embedded-template": "0.19.0",
+        "tree-sitter-html": "0.19.0"
+      },
+      "devDependencies": {
+        "coffeelint": "^1.10.1",
+        "dedent": "^0.7.0"
+      },
+      "engines": {
+        "atom": "*",
+        "node": "*"
+      }
+    },
+    "node_modules/atom-grammar-test": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/atom-grammar-test/-/atom-grammar-test-0.6.4.tgz",
+      "integrity": "sha1-2KU1A9H+k5mX9Ji3SirDEARKfU4=",
+      "dependencies": {
+        "chevrotain": "^0.18.0",
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-0.18.0.tgz",
+      "integrity": "sha1-sodxTjFZC64sXR4vYRZz7+xHnYA="
+    },
+    "node_modules/coffee-script": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+      "integrity": "sha1-vxxHrWREOg2V0S3ysUfMCk2q1uk=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coffeelint": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.2.tgz",
+      "integrity": "sha512-6mzgOo4zb17WfdrSui/cSUEgQ0AQkW3gXDht+6lHkfkqGUtSYKwGdGcXsDfAyuScVzTlTtKdfwkAlJWfqul7zg==",
+      "dev": true,
+      "dependencies": {
+        "coffee-script": "~1.11.0",
+        "glob": "^7.0.6",
+        "ignore": "^3.0.9",
+        "optimist": "^0.6.1",
+        "resolve": "^0.6.3",
+        "strip-json-comments": "^1.0.2"
+      },
+      "bin": {
+        "coffeelint": "bin/coffeelint"
+      },
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+      "dev": true
+    },
+    "node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true,
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/tree-sitter-embedded-template": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-embedded-template/-/tree-sitter-embedded-template-0.19.0.tgz",
+      "integrity": "sha512-J80/G0xRHlIxv0gNfvW8zHMZeD9nqnSKV4nMB5t0RAW/W/nM5io/gojk0ppWuWKMuyYNs3KKXIqP0i43jVkdkQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      }
+    },
+    "node_modules/tree-sitter-html": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-html/-/tree-sitter-html-0.19.0.tgz",
+      "integrity": "sha512-xH6XGSBWzb4oU/aG6gouMRQKsd96iKuy0zboUqo3wcIWrA++q9a7CmQTSeIINiSfOXjT2ZLJciXFDgAh6h04Bw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
   "dependencies": {
     "atom-grammar-test": {
       "version": "0.6.4",
@@ -171,19 +428,19 @@
       "dev": true
     },
     "tree-sitter-embedded-template": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-embedded-template/-/tree-sitter-embedded-template-0.15.2.tgz",
-      "integrity": "sha512-DHT4KAzFbtj/5XhSZWCkf7LP1SYIi4gSSOZHVH9SqEv1DIc9rSmgNO3rzIyMoRclusLoL2susmokL/hYkj56+A==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-embedded-template/-/tree-sitter-embedded-template-0.19.0.tgz",
+      "integrity": "sha512-J80/G0xRHlIxv0gNfvW8zHMZeD9nqnSKV4nMB5t0RAW/W/nM5io/gojk0ppWuWKMuyYNs3KKXIqP0i43jVkdkQ==",
       "requires": {
-        "nan": "^2.0.0"
+        "nan": "^2.14.0"
       }
     },
     "tree-sitter-html": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-html/-/tree-sitter-html-0.15.1.tgz",
-      "integrity": "sha512-hf1dTxB6OIlDk+mkxLaHC1boKUxmnp0qxt8nApZZ6zf3VWj5FeYlWv93GX5+gLL3NkLAjaUKGZGFXpR+wE97Jg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-html/-/tree-sitter-html-0.19.0.tgz",
+      "integrity": "sha512-xH6XGSBWzb4oU/aG6gouMRQKsd96iKuy0zboUqo3wcIWrA++q9a7CmQTSeIINiSfOXjT2ZLJciXFDgAh6h04Bw==",
       "requires": {
-        "nan": "^2.10.0"
+        "nan": "^2.14.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.3",
-    "tree-sitter-embedded-template": "^0.15.2",
-    "tree-sitter-html": "^0.15.0"
+    "tree-sitter-embedded-template": "0.19.0",
+    "tree-sitter-html": "0.19.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1",


### PR DESCRIPTION
`^version` means install any version that is compatible with the range.
This means npm can even install tree-sitter-javascript version 0.15
since in semver 0.15 should be compatible with 0.19. tree-sitter seems
to have broken semver. 0.15 is not compatible with 0.19